### PR TITLE
Add chatless formation apply and status query protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,14 @@ Server -> Addon:  MBOT ROSTER~...
 
 Addon  -> Server: MBOT GET~STATES
 Server -> Addon:  MBOT STATES~...
+
+Addon  -> Server: MBOT RUN~FORMATION~GROUP~~<token>~<formation>
+Server -> Addon:  MBOT FORMATION_ACK~GROUP~~<token>~<success>~<failure>~<formation>
+
+Addon  -> Server: MBOT GET~FORMATIONS~GROUP~~<token>
+Server -> Addon:  MBOT FORMATIONS_BEGIN~<token>~<count>
+Server -> Addon:  MBOT FORMATIONS_ITEM~<token>~<botName>~<formation>
+Server -> Addon:  MBOT FORMATIONS_END~<token>~<sentCount>
 ```
 
 The exact payloads are consumed internally by the MultiBot addon.
@@ -341,6 +349,10 @@ The exact payloads are consumed internally by the MultiBot addon.
   <tr>
     <td><code>GET~STATES</code></td>
     <td>Refresh bot state flags and UI state data.</td>
+  </tr>
+  <tr>
+    <td><code>GET~FORMATIONS</code></td>
+    <td>Read the effective current formation of every controllable bot in the player's current party or raid and return one structured item per bot.</td>
   </tr>
   <tr>
     <td><code>GET~DETAILS</code></td>
@@ -439,6 +451,10 @@ The exact payloads are consumed internally by the MultiBot addon.
     <td>Run whitelist-only disperse distance and disable commands.</td>
   </tr>
   <tr>
+    <td><code>RUN~FORMATION</code></td>
+    <td>Apply one validated formation to every controllable bot in the player's current party or raid and return aggregate success/failure counts.</td>
+  </tr>
+  <tr>
     <td><code>RUN~LOOT</code></td>
     <td>Run whitelist-only loot rules and loot list commands without addon-side chat parsing.</td>
   </tr>
@@ -463,6 +479,8 @@ ss ?
 ```
 
 The bridge only replaces the automatic data-refresh paths used by the addon UI.
+
+Formation selection and inspection are also bridge-first. `RUN~FORMATION` applies a validated formation across the whole current party or raid, while `GET~FORMATIONS` reads the effective value from each controllable bot. Neither path requires PARTY, RAID, whisper or `TellMaster` output. The `GROUP` scope intentionally covers the complete party or raid; individual raid subgroups are not targeted.
 
 ---
 
@@ -523,6 +541,24 @@ MultiBot.allowLegacyChatFallback = false
 ```
 
 Only enable legacy fallback temporarily for debugging.
+
+</details>
+
+<details>
+<summary><strong>Formation changes or formation status do not reach the addon</strong></summary>
+
+Check the server console for the structured formation requests and responses:
+
+```text
+RUN~FORMATION~GROUP~~<token>~circle
+FORMATION_ACK~GROUP~~<token>~<success>~<failure>~circle
+GET~FORMATIONS~GROUP~~<token>
+FORMATIONS_BEGIN~<token>~<count>
+FORMATIONS_ITEM~<token>~<botName>~<formation>
+FORMATIONS_END~<token>~<sentCount>
+```
+
+Only controllable bots in the player's current party or raid are included. The bridge does not expose or target bots outside that group, and it does not apply formations separately to raid subgroups.
 
 </details>
 
@@ -638,6 +674,7 @@ Design goals:
 - Keep the bridge protocol stable enough for addon-side consumers.
 - Avoid unnecessary server-side behavior changes outside the bridge.
 - Keep the module installable as a normal AzerothCore module.
+- Keep formation operations inside the bridge by using the existing Playerbots `FormationValue` API; no modification of `mod-playerbots` is required.
 
 ---
 

--- a/src/MultiBotBridge.cpp
+++ b/src/MultiBotBridge.cpp
@@ -18,6 +18,7 @@
 #include "RandomPlayerbotMgr.h"
 #include "ReputationMgr.h"
 #include "AiObjectContext.h"
+#include "Formations.h"
 #include "ScriptedGossip.h"
 #include "ScriptMgr.h"
 #include "SharedDefines.h"
@@ -63,6 +64,8 @@ void RunOutfitCommand(Player* requester, ChatMsg replyType, std::string const& b
 void RunTrainerLearnCommand(Player* requester, ChatMsg replyType, std::string const& botName, std::string const& requestToken, std::string const& trainerEntryValue, std::string const& spellIdValue);
 void RunProfessionRecipeCraftCommand(Player* requester, ChatMsg replyType, std::string const& botName, std::string const& requestToken, std::string const& skillIdValue, std::string const& spellIdValue, std::string const& itemIdValue);
 void RunInventoryItemActionCommand(Player* requester, ChatMsg replyType, std::string const& botName, std::string const& requestToken, std::string const& actionValue, std::string const& itemIdValue, std::string const& countValue);
+void RunFormationCommand(Player* requester, ChatMsg replyType, std::string const& scopeValue, std::string const& encodedTarget, std::string const& requestToken, std::string const& encodedFormation);
+void SendFormationPackets(Player* requester, ChatMsg replyType, std::string const& scopeValue, std::string const& encodedTarget, std::string const& requestToken);
 void SendBotReputationPackets(Player* requester, ChatMsg replyType, std::string const& botName, std::string const& requestToken);
 void SendBotEmblemPackets(Player* requester, ChatMsg replyType, std::string const& botName, std::string const& requestToken);
 uint32 GetPct(uint32 current, uint32 max);
@@ -80,6 +83,12 @@ std::string Trim(std::string const& value)
 std::string ToUpper(std::string value)
 {
     std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) { return std::toupper(c); });
+    return value;
+}
+
+std::string ToLower(std::string value)
+{
+    std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) { return std::tolower(c); });
     return value;
 }
 
@@ -3696,6 +3705,151 @@ bool BotMatchesCombatScope(Player* requester, Player* bot, std::string const& sc
     return BotMatchesRTIScope(requester, bot, scope, target);
 }
 
+bool IsAllowedFormationName(std::string const& formation)
+{
+    static std::set<std::string> const allowed =
+    {
+        "arrow",
+        "queue",
+        "near",
+        "melee",
+        "line",
+        "circle",
+        "chaos",
+        "shield"
+    };
+
+    return allowed.find(formation) != allowed.end();
+}
+
+void SendFormationPackets(Player* requester, ChatMsg replyType, std::string const& scopeValue, std::string const& encodedTarget, std::string const& requestToken)
+{
+    std::string const scope = ToUpper(Trim(scopeValue));
+    std::string const target = Trim(UrlDecodeField(encodedTarget));
+    std::string const token = Trim(requestToken);
+
+    std::vector<std::pair<std::string, std::string>> entries;
+
+    if (requester && scope == "GROUP" && target.empty() && !token.empty() && token.size() <= 64)
+    {
+        Group* const requesterGroup = requester->GetGroup();
+        if (requesterGroup)
+        {
+            for (Player* const bot : GetBridgeVisibleBots(requester))
+            {
+                if (!bot || bot->GetGroup() != requesterGroup)
+                    continue;
+
+                std::string formation = "?";
+
+                PlayerbotAI* const botAI = GetBotAI(bot);
+                if (botAI && botAI->GetAiObjectContext())
+                {
+                    AiObjectContext* const context = botAI->GetAiObjectContext();
+                    FormationValue* const value = (FormationValue*)context->GetValue<Formation*>("formation");
+                    if (value)
+                    {
+                        formation = Trim(value->Save());
+                        if (formation.empty())
+                            formation = "?";
+                    }
+                }
+
+                entries.emplace_back(bot->GetName(), formation);
+            }
+        }
+    }
+
+    std::sort(entries.begin(), entries.end(), [](std::pair<std::string, std::string> const& left, std::pair<std::string, std::string> const& right)
+    {
+        return left.first < right.first;
+    });
+
+    std::ostringstream beginPayload;
+    beginPayload << token << kFieldSeparator << entries.size();
+    SendAddonPacket(requester, replyType, "FORMATIONS_BEGIN", beginPayload.str());
+
+    uint32 sent = 0;
+    for (std::pair<std::string, std::string> const& entry : entries)
+    {
+        std::ostringstream itemPayload;
+        itemPayload << token
+            << kFieldSeparator << UrlEncodeField(entry.first)
+            << kFieldSeparator << UrlEncodeField(entry.second);
+
+        SendAddonPacket(requester, replyType, "FORMATIONS_ITEM", itemPayload.str());
+        ++sent;
+    }
+
+    std::ostringstream endPayload;
+    endPayload << token << kFieldSeparator << sent;
+    SendAddonPacket(requester, replyType, "FORMATIONS_END", endPayload.str());
+}
+
+bool ApplyNativeFormation(Player* bot, std::string const& formation)
+{
+    if (!bot || !IsAllowedFormationName(formation))
+        return false;
+
+    PlayerbotAI* const botAI = GetBotAI(bot);
+    if (!botAI)
+        return false;
+
+    AiObjectContext* const context = botAI->GetAiObjectContext();
+    if (!context)
+        return false;
+
+    FormationValue* const value = static_cast<FormationValue*>(context->GetValue<Formation*>("formation"));
+    if (!value || !value->Load(formation))
+        return false;
+
+    return value->Save() == formation;
+}
+
+void RunFormationCommand(Player* requester, ChatMsg replyType, std::string const& scopeValue, std::string const& encodedTarget, std::string const& requestToken, std::string const& encodedFormation)
+{
+    std::string const scope = ToUpper(Trim(scopeValue));
+    std::string const target = Trim(UrlDecodeField(encodedTarget));
+    std::string const token = Trim(requestToken);
+    std::string const formation = ToLower(Trim(UrlDecodeField(encodedFormation)));
+    uint32 succeeded = 0;
+    uint32 failed = 0;
+
+    bool const validRequest =
+        requester &&
+        scope == "GROUP" &&
+        target.empty() &&
+        !token.empty() &&
+        token.size() <= 64 &&
+        formation.size() <= 16 &&
+        IsAllowedFormationName(formation);
+
+    Group* const requesterGroup = validRequest ? requester->GetGroup() : nullptr;
+    if (requesterGroup)
+    {
+        for (Player* const bot : GetBridgeVisibleBots(requester))
+        {
+            if (!bot || bot->GetGroup() != requesterGroup)
+                continue;
+
+            if (ApplyNativeFormation(bot, formation))
+                ++succeeded;
+            else
+                ++failed;
+        }
+    }
+
+    std::ostringstream payload;
+    payload << scope
+        << kFieldSeparator << UrlEncodeField(target)
+        << kFieldSeparator << token
+        << kFieldSeparator << succeeded
+        << kFieldSeparator << failed
+        << kFieldSeparator << UrlEncodeField(formation);
+
+    SendAddonPacket(requester, replyType, "FORMATION_ACK", payload.str());
+}
+
 void RunRTICommand(Player* requester, ChatMsg replyType, std::string const& scopeValue, std::string const& encodedTarget, std::string const& requestToken, std::string const& encodedCommand)
 {
     std::string const scope = ToUpper(Trim(scopeValue));
@@ -4180,6 +4334,15 @@ bool HandleBridgeOpcode(Player* player, ChatMsg replyType, std::string const& op
             return true;
         }
 
+        if (requestType == "FORMATIONS")
+        {
+            std::pair<std::string, std::string> const scopeSplit = SplitOnce(request.second, kFieldSeparator);
+            std::pair<std::string, std::string> const targetSplit = SplitOnce(scopeSplit.second, kFieldSeparator);
+
+            SendFormationPackets(player, replyType, scopeSplit.first, targetSplit.first, targetSplit.second);
+            return true;
+        }
+
         if (requestType == "TALENT_SPEC_LIST")
         {
             std::pair<std::string, std::string> const specRequest = SplitOnce(request.second, kFieldSeparator);
@@ -4345,6 +4508,16 @@ bool HandleBridgeOpcode(Player* player, ChatMsg replyType, std::string const& op
             std::pair<std::string, std::string> const actionRequest = SplitOnce(tokenRequest.second, kFieldSeparator);
             std::pair<std::string, std::string> const itemRequest = SplitOnce(actionRequest.second, kFieldSeparator);
             RunInventoryItemActionCommand(player, replyType, botRequest.first, tokenRequest.first, actionRequest.first, itemRequest.first, itemRequest.second);
+            return true;
+        }
+
+        if (requestType == "FORMATION")
+        {
+            std::pair<std::string, std::string> const scopeSplit = SplitOnce(request.second, kFieldSeparator);
+            std::pair<std::string, std::string> const targetSplit = SplitOnce(scopeSplit.second, kFieldSeparator);
+            std::pair<std::string, std::string> const tokenSplit = SplitOnce(targetSplit.second, kFieldSeparator);
+
+            RunFormationCommand(player, replyType, scopeSplit.first, targetSplit.first, tokenSplit.first, tokenSplit.second);
             return true;
         }
 


### PR DESCRIPTION
Adds validated party/raid-wide formation write and read endpoints so MultiBot can apply and inspect formations without PARTY, RAID, whisper or TellMaster output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New features**
  * Added commands to view and modify the formations of bots in a group.
  * Validation of allowed formations before applying them.
  * Added structured responses confirming available formations and performed changes.

* **Documentation**
  * Documentation of the commands, their scope, expected responses, and behavior without chat output.
  * Added a diagnostic procedure and clarifications on the use of the existing API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->