### PR TITLE
p2a-outfit-chatless

### DIFF
--- a/src/MultiBotBridge.cpp
+++ b/src/MultiBotBridge.cpp
@@ -14,6 +14,7 @@
 #include "Player.h"
 #include "PlayerbotAI.h"
 #include "PlayerbotMgr.h"
+#include "PlayerbotRepository.h"
 #include "Playerbots.h"
 #include "RandomPlayerbotMgr.h"
 #include "ReputationMgr.h"
@@ -69,6 +70,7 @@ std::size_t constexpr kStrategyMutationRateLimit = 24;
 std::chrono::milliseconds constexpr kStrategyMutationRateWindow(2000);
 char const* const kStateFramingCapability = "STATE_FRAMING_V1";
 char const* const kStrategyMutationCapability = "STRATEGY_MUTATION_V1";
+char const* const kOutfitCapability = "OUTFIT_V1";
 uint32 constexpr kMaxItemActionCount = 1000;
 
 enum class BridgePayloadStatus
@@ -3023,17 +3025,7 @@ bool IsAllowedOutfitCommandSuffix(std::string const& suffix)
     return parts.action == "EQUIP" || parts.action == "REPLACE" || parts.action == "UPDATE" || parts.action == "RESET";
 }
 
-bool IsUpdateOutfitCommandSuffix(std::string const& suffix)
-{
-    OutfitCommandParts const parts = ParseOutfitCommandSuffix(suffix);
-    return parts.action == "UPDATE";
-}
 
-bool IsDirectBridgeOutfitCommandSuffix(std::string const& suffix)
-{
-    OutfitCommandParts const parts = ParseOutfitCommandSuffix(suffix);
-    return parts.action == "EQUIP" || parts.action == "REPLACE" || parts.action == "UPDATE" || parts.action == "RESET";
-}
 
 std::string SanitizeOutfitCommandSuffix(std::string suffix)
 {
@@ -3265,13 +3257,6 @@ bool ApplyBridgeNativeOutfitCommand(Player* bot, std::string const& suffix)
         if (!equippedAny)
             return false;
 
-        std::ostringstream out;
-        if (parts.action == "REPLACE")
-            out << "Replacing current equip with outfit " << parts.name;
-        else
-            out << "Equipping outfit " << parts.name;
-
-        botAI->TellMaster(out.str());
         return true;
     }
 
@@ -3281,11 +3266,21 @@ bool ApplyBridgeNativeOutfitCommand(Player* bot, std::string const& suffix)
         if (entries.empty())
             return false;
 
-        return SaveOutfitEntries(botAI, parts.name, entries);
+        if (!SaveOutfitEntries(botAI, parts.name, entries))
+            return false;
+
+        PlayerbotRepository::instance().Save(botAI);
+        return true;
     }
 
     if (parts.action == "RESET")
-        return SaveOutfitEntries(botAI, parts.name, std::vector<uint32>());
+    {
+        if (!SaveOutfitEntries(botAI, parts.name, std::vector<uint32>()))
+            return false;
+
+        PlayerbotRepository::instance().Save(botAI);
+        return true;
+    }
 
     return false;
 }
@@ -3683,17 +3678,11 @@ void RunOutfitCommand(Player* requester, ChatMsg replyType, std::string const& b
     Player* const bot = FindBotByName(requester, trimmedBotName);
     std::string const effectiveBotName = bot ? bot->GetName() : trimmedBotName;
 
+    (void)persistToken;
+
     bool ok = false;
     if (bot && IsAllowedOutfitCommandSuffix(suffix))
-    {
-        if (IsDirectBridgeOutfitCommandSuffix(suffix))
-            ok = ApplyBridgeNativeOutfitCommand(bot, suffix);
-        else
-            ok = ExecuteSilentBotCommand(requester, bot, "outfit " + suffix);
-
-        if (ok && IsUpdateOutfitCommandSuffix(suffix) && Trim(persistToken) == "1")
-            ExecuteSilentBotCommand(requester, bot, "nc +chat");
-    }
+        ok = ApplyBridgeNativeOutfitCommand(bot, suffix);
 
     std::ostringstream payload;
     payload << UrlEncodeField(effectiveBotName)
@@ -5430,7 +5419,7 @@ bool HandleBridgeOpcode(Player* player, ChatMsg replyType, std::string const& op
             player,
             replyType,
             "CAPS",
-            std::string(kStateFramingCapability) + "," + kStrategyMutationCapability);
+            std::string(kStateFramingCapability) + "," + kStrategyMutationCapability + "," + kOutfitCapability);
         return true;
     }
 

--- a/src/MultiBotBridge.cpp
+++ b/src/MultiBotBridge.cpp
@@ -3094,7 +3094,7 @@ bool SaveOutfitEntries(PlayerbotAI* botAI, std::string const& outfitName, std::v
     return true;
 }
 
-bool ApplyBridgeNativeOutfitCommand(Player* bot, std::string const& suffix)
+bool ApplyBridgeNativeOutfitCommand(Player* bot, std::string const& suffix, bool persist)
 {
     if (!bot)
         return false;
@@ -3269,7 +3269,8 @@ bool ApplyBridgeNativeOutfitCommand(Player* bot, std::string const& suffix)
         if (!SaveOutfitEntries(botAI, parts.name, entries))
             return false;
 
-        PlayerbotRepository::instance().Save(botAI);
+        if (persist)
+            PlayerbotRepository::instance().Save(botAI);
         return true;
     }
 
@@ -3278,7 +3279,8 @@ bool ApplyBridgeNativeOutfitCommand(Player* bot, std::string const& suffix)
         if (!SaveOutfitEntries(botAI, parts.name, std::vector<uint32>()))
             return false;
 
-        PlayerbotRepository::instance().Save(botAI);
+        if (persist)
+            PlayerbotRepository::instance().Save(botAI);
         return true;
     }
 
@@ -3678,11 +3680,11 @@ void RunOutfitCommand(Player* requester, ChatMsg replyType, std::string const& b
     Player* const bot = FindBotByName(requester, trimmedBotName);
     std::string const effectiveBotName = bot ? bot->GetName() : trimmedBotName;
 
-    (void)persistToken;
+    bool const persist = persistToken == "1";
 
     bool ok = false;
     if (bot && IsAllowedOutfitCommandSuffix(suffix))
-        ok = ApplyBridgeNativeOutfitCommand(bot, suffix);
+        ok = ApplyBridgeNativeOutfitCommand(bot, suffix, persist);
 
     std::ostringstream payload;
     payload << UrlEncodeField(effectiveBotName)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Ajout de la prise en charge de la capacité `OUTFIT_V1`.
  * Les commandes de mise à jour et de réinitialisation des tenues enregistrent désormais explicitement les modifications.

* **Améliorations**
  * Les commandes de tenue suivent un traitement unifié et plus fiable.
  * La réponse de capacités indique correctement la prise en charge des fonctionnalités de tenue.
  * Les confirmations inutiles et l’exécution silencieuse ont été supprimées pour clarifier le comportement des commandes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->