### PR TITLE
P2B: Add INVENTORY_V1 capability for native inventory refresh

### DIFF
--- a/src/MultiBotBridge.cpp
+++ b/src/MultiBotBridge.cpp
@@ -71,6 +71,7 @@ std::chrono::milliseconds constexpr kStrategyMutationRateWindow(2000);
 char const* const kStateFramingCapability = "STATE_FRAMING_V1";
 char const* const kStrategyMutationCapability = "STRATEGY_MUTATION_V1";
 char const* const kOutfitCapability = "OUTFIT_V1";
+char const* const kInventoryCapability = "INVENTORY_V1";
 uint32 constexpr kMaxItemActionCount = 1000;
 
 enum class BridgePayloadStatus
@@ -5421,7 +5422,7 @@ bool HandleBridgeOpcode(Player* player, ChatMsg replyType, std::string const& op
             player,
             replyType,
             "CAPS",
-            std::string(kStateFramingCapability) + "," + kStrategyMutationCapability + "," + kOutfitCapability);
+            std::string(kStateFramingCapability) + "," + kStrategyMutationCapability + "," + kOutfitCapability + "," + kInventoryCapability);
         return true;
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Ajout de la prise en charge de la capacité `INVENTORY_V1`.
  * Cette capacité est désormais annoncée lors de l’échange d’initialisation du protocole.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->