### PR TITLE
Add safe bridge-first SELL_VENDOR inventory action

### DIFF
--- a/src/MultiBotBridge.cpp
+++ b/src/MultiBotBridge.cpp
@@ -10,6 +10,7 @@
 #include "GuildMgr.h"
 #include "Item.h"
 #include "ItemPackets.h"
+#include "ItemUsageValue.h"
 #include "ObjectMgr.h"
 #include "Player.h"
 #include "PlayerbotAI.h"
@@ -3613,6 +3614,361 @@ uint32 MoveMatchingGuildBankItemsToBags(Player* requester, Player* bot, uint32 i
     return moved;
 }
 
+bool IsBridgeSellGreyCandidate(Item* item)
+{
+    if (!item)
+        return false;
+
+    ItemTemplate const* const proto = item->GetTemplate();
+    if (!proto)
+        return false;
+
+    if (proto->Quality != ITEM_QUALITY_POOR || !proto->SellPrice)
+        return false;
+
+    if (proto->Class == ITEM_CLASS_QUEST || proto->Class == ITEM_CLASS_KEY)
+        return false;
+
+    // Keep the same explicit protection already enforced by the addon.
+    if (item->GetEntry() == 6948)
+        return false;
+
+    return true;
+}
+
+Creature* FindNearbyInteractiveVendor(Player* bot)
+{
+    PlayerbotAI* const botAI = GetBotAI(bot);
+    if (!bot || !botAI || !botAI->GetAiObjectContext())
+        return nullptr;
+
+    AiObjectContext* const context = botAI->GetAiObjectContext();
+    GuidVector const npcs = *context->GetValue<GuidVector>("nearest npcs");
+    for (ObjectGuid const guid : npcs)
+    {
+        Creature* const creature = bot->GetNPCIfCanInteractWith(guid, UNIT_NPC_FLAG_VENDOR);
+        if (creature)
+            return creature;
+    }
+
+    return nullptr;
+}
+
+void CollectBridgeSellGreyCandidate(Item* item, std::vector<ObjectGuid>& itemGuids)
+{
+    if (IsBridgeSellGreyCandidate(item))
+        itemGuids.push_back(item->GetGUID());
+}
+
+uint32 SellGreyBagItems(Player* bot, std::string& reason)
+{
+    if (!bot || !bot->GetSession())
+    {
+        reason = "BAD_REQUEST";
+        return 0;
+    }
+
+    Creature* const vendor = FindNearbyInteractiveVendor(bot);
+    if (!vendor)
+    {
+        reason = "VENDOR_NOT_FOUND";
+        return 0;
+    }
+
+    std::vector<ObjectGuid> itemGuids;
+
+    // Snapshot candidate GUIDs before invoking the sell handler so inventory
+    // mutations cannot invalidate the bag iteration.
+    for (uint8 slot = INVENTORY_SLOT_ITEM_START; slot < INVENTORY_SLOT_ITEM_END; ++slot)
+        CollectBridgeSellGreyCandidate(bot->GetItemByPos(INVENTORY_SLOT_BAG_0, slot), itemGuids);
+
+    for (uint8 bag = INVENTORY_SLOT_BAG_START; bag < INVENTORY_SLOT_BAG_END; ++bag)
+    {
+        Bag* const pBag = static_cast<Bag*>(bot->GetItemByPos(INVENTORY_SLOT_BAG_0, bag));
+        if (!pBag)
+            continue;
+
+        for (uint8 slot = 0; slot < pBag->GetBagSize(); ++slot)
+            CollectBridgeSellGreyCandidate(pBag->GetItemByPos(slot), itemGuids);
+    }
+
+    if (itemGuids.empty())
+    {
+        reason = "ITEM_NOT_FOUND";
+        return 0;
+    }
+
+    PlayerbotAI* const botAI = GetBotAI(bot);
+    uint32 sold = 0;
+
+    for (ObjectGuid const itemGuid : itemGuids)
+    {
+        Item* const item = bot->GetItemByGuid(itemGuid);
+        if (!IsBridgeSellGreyCandidate(item))
+            continue;
+
+        uint32 const itemId = item->GetEntry();
+        uint32 const before = bot->GetItemCount(itemId, false);
+        uint32 const moneyBefore = bot->GetMoney();
+
+        WorldPacket packet(CMSG_SELL_ITEM);
+        packet << vendor->GetGUID() << itemGuid << uint32(0);
+
+        WorldPackets::Item::SellItem sellPacket(std::move(packet));
+        sellPacket.Read();
+        bot->GetSession()->HandleSellItemOpcode(sellPacket);
+
+        // Match Playerbots SellAction semantics when the gold cheat is active,
+        // without calling SellAction/TellMaster and therefore without chat spam.
+        if (botAI && botAI->HasCheat(BotCheatMask::gold))
+            bot->SetMoney(moneyBefore);
+
+        uint32 const after = bot->GetItemCount(itemId, false);
+        if (before > after)
+            sold += before - after;
+    }
+
+    if (!sold && reason.empty())
+        reason = "FAILED";
+
+    return sold;
+}
+
+void AddBridgeCraftOutputsFromSpellInfo(SpellInfo const* spellInfo, std::set<uint32>& itemIds)
+{
+    if (!spellInfo)
+        return;
+
+    for (uint8 i = 0; i < MAX_SPELL_EFFECTS; ++i)
+    {
+        SpellEffectInfo const& effect = spellInfo->Effects[i];
+        if ((effect.Effect == SPELL_EFFECT_CREATE_ITEM || effect.Effect == SPELL_EFFECT_CREATE_ITEM_2) &&
+            effect.ItemType > 0)
+            itemIds.insert(static_cast<uint32>(effect.ItemType));
+    }
+}
+
+void AddBridgeCraftOutputsFromSpell(uint32 spellId, std::set<uint32>& itemIds)
+{
+    SpellInfo const* const spellInfo = sSpellMgr->GetSpellInfo(spellId);
+    if (!spellInfo)
+        return;
+
+    AddBridgeCraftOutputsFromSpellInfo(spellInfo, itemIds);
+
+    // One triggered-spell level, matching the audited Playerbots pattern.
+    // Only created outputs are recorded; reagents are never treated as crafts.
+    for (uint8 i = 0; i < MAX_SPELL_EFFECTS; ++i)
+    {
+        uint32 const triggerSpell = spellInfo->Effects[i].TriggerSpell;
+        if (triggerSpell)
+            AddBridgeCraftOutputsFromSpellInfo(sSpellMgr->GetSpellInfo(triggerSpell), itemIds);
+    }
+}
+
+uint32 GetBridgeRecipeSkillId(ItemTemplate const* recipe)
+{
+    if (!recipe || recipe->Class != ITEM_CLASS_RECIPE)
+        return 0;
+
+    switch (recipe->SubClass)
+    {
+        case ITEM_SUBCLASS_LEATHERWORKING_PATTERN: return SKILL_LEATHERWORKING;
+        case ITEM_SUBCLASS_TAILORING_PATTERN: return SKILL_TAILORING;
+        case ITEM_SUBCLASS_ENGINEERING_SCHEMATIC: return SKILL_ENGINEERING;
+        case ITEM_SUBCLASS_BLACKSMITHING: return SKILL_BLACKSMITHING;
+        case ITEM_SUBCLASS_COOKING_RECIPE: return SKILL_COOKING;
+        case ITEM_SUBCLASS_ALCHEMY_RECIPE: return SKILL_ALCHEMY;
+        case ITEM_SUBCLASS_FIRST_AID_MANUAL: return SKILL_FIRST_AID;
+        case ITEM_SUBCLASS_ENCHANTING_FORMULA: return SKILL_ENCHANTING;
+        case ITEM_SUBCLASS_JEWELCRAFTING_RECIPE: return SKILL_JEWELCRAFTING;
+        case ITEM_SUBCLASS_FISHING_MANUAL: return SKILL_FISHING;
+        default: return 0;
+    }
+}
+
+std::set<uint32> BuildBridgeCraftProtectedItemIds(PlayerbotAI* botAI)
+{
+    std::set<uint32> itemIds;
+    if (!botAI)
+        return itemIds;
+
+    std::array<SkillType, 14> const skills = {
+        SKILL_ALCHEMY,
+        SKILL_ENCHANTING,
+        SKILL_SKINNING,
+        SKILL_TAILORING,
+        SKILL_LEATHERWORKING,
+        SKILL_ENGINEERING,
+        SKILL_HERBALISM,
+        SKILL_INSCRIPTION,
+        SKILL_MINING,
+        SKILL_BLACKSMITHING,
+        SKILL_COOKING,
+        SKILL_FIRST_AID,
+        SKILL_FISHING,
+        SKILL_JEWELCRAFTING
+    };
+
+    for (SkillType const skill : skills)
+    {
+        if (!botAI->HasSkill(skill))
+            continue;
+
+        for (SkillLineAbilityEntry const* const ability :
+             GetSkillLineAbilitiesBySkillLine(static_cast<uint32>(skill)))
+        {
+            if (ability)
+                AddBridgeCraftOutputsFromSpell(ability->Spell, itemIds);
+        }
+    }
+
+    // Conservative recipe fallback audited from Playerbots.
+    std::vector<ItemTemplate*> const* const itemTemplates = sObjectMgr->GetItemTemplateStoreFast();
+    if (!itemTemplates)
+        return itemIds;
+
+    for (ItemTemplate const* const recipe : *itemTemplates)
+    {
+        uint32 const skillId = GetBridgeRecipeSkillId(recipe);
+        if (!skillId || !botAI->HasSkill(static_cast<SkillType>(skillId)))
+            continue;
+
+        for (uint8 i = 0; i < MAX_ITEM_PROTO_SPELLS; ++i)
+        {
+            uint32 const spellId = recipe->Spells[i].SpellId;
+            if (spellId)
+                AddBridgeCraftOutputsFromSpell(spellId, itemIds);
+        }
+    }
+
+    return itemIds;
+}
+
+bool IsBridgeSellVendorCandidate(Player* bot, PlayerbotAI* botAI, Item* item,
+                                 std::set<uint32> const& protectedCraftItemIds)
+{
+    if (!bot || !botAI || !item)
+        return false;
+
+    ItemTemplate const* const proto = item->GetTemplate();
+    if (!proto || !proto->SellPrice)
+        return false;
+
+    if (proto->Class == ITEM_CLASS_QUEST || proto->Class == ITEM_CLASS_KEY)
+        return false;
+
+    if (item->GetEntry() == 6948)
+        return false;
+
+    // Fail-safe workaround for the audited Playerbots ammo-class condition bug.
+    if (proto->Class == ITEM_CLASS_PROJECTILE)
+        return false;
+
+    // Exact signed-craft protection.
+    if (item->GetGuidValue(ITEM_FIELD_CREATOR) == bot->GetGUID())
+        return false;
+
+    // Conservative protection for unsigned/stackable profession outputs.
+    if (protectedCraftItemIds.find(item->GetEntry()) != protectedCraftItemIds.end())
+        return false;
+
+    AiObjectContext* const context = botAI->GetAiObjectContext();
+    if (!context)
+        return false;
+
+    ItemUsage const usage = context->GetValue<ItemUsage>("item usage", item->GetEntry())->Get();
+    return usage == ITEM_USAGE_VENDOR || usage == ITEM_USAGE_AH;
+}
+
+void CollectBridgeSellVendorCandidate(Player* bot, PlayerbotAI* botAI, Item* item,
+                                      std::set<uint32> const& protectedCraftItemIds,
+                                      std::vector<ObjectGuid>& itemGuids)
+{
+    if (IsBridgeSellVendorCandidate(bot, botAI, item, protectedCraftItemIds))
+        itemGuids.push_back(item->GetGUID());
+}
+
+uint32 SellVendorBagItems(Player* bot, std::string& reason)
+{
+    if (!bot || !bot->GetSession())
+    {
+        reason = "BAD_REQUEST";
+        return 0;
+    }
+
+    Creature* const vendor = FindNearbyInteractiveVendor(bot);
+    if (!vendor)
+    {
+        reason = "VENDOR_NOT_FOUND";
+        return 0;
+    }
+
+    PlayerbotAI* const botAI = GetBotAI(bot);
+    if (!botAI || !botAI->GetAiObjectContext())
+    {
+        reason = "FAILED";
+        return 0;
+    }
+
+    std::set<uint32> const protectedCraftItemIds = BuildBridgeCraftProtectedItemIds(botAI);
+    std::vector<ObjectGuid> itemGuids;
+
+    // Snapshot GUIDs before native selling. Uncertainty means keep.
+    for (uint8 slot = INVENTORY_SLOT_ITEM_START; slot < INVENTORY_SLOT_ITEM_END; ++slot)
+        CollectBridgeSellVendorCandidate(
+            bot, botAI, bot->GetItemByPos(INVENTORY_SLOT_BAG_0, slot), protectedCraftItemIds, itemGuids);
+
+    for (uint8 bag = INVENTORY_SLOT_BAG_START; bag < INVENTORY_SLOT_BAG_END; ++bag)
+    {
+        Bag* const pBag = static_cast<Bag*>(bot->GetItemByPos(INVENTORY_SLOT_BAG_0, bag));
+        if (!pBag)
+            continue;
+
+        for (uint8 slot = 0; slot < pBag->GetBagSize(); ++slot)
+            CollectBridgeSellVendorCandidate(
+                bot, botAI, pBag->GetItemByPos(slot), protectedCraftItemIds, itemGuids);
+    }
+
+    if (itemGuids.empty())
+    {
+        reason = "ITEM_NOT_FOUND";
+        return 0;
+    }
+
+    uint32 sold = 0;
+
+    for (ObjectGuid const itemGuid : itemGuids)
+    {
+        Item* const item = bot->GetItemByGuid(itemGuid);
+        if (!IsBridgeSellVendorCandidate(bot, botAI, item, protectedCraftItemIds))
+            continue;
+
+        uint32 const itemId = item->GetEntry();
+        uint32 const before = bot->GetItemCount(itemId, false);
+        uint32 const moneyBefore = bot->GetMoney();
+
+        WorldPacket packet(CMSG_SELL_ITEM);
+        packet << vendor->GetGUID() << itemGuid << uint32(0);
+
+        WorldPackets::Item::SellItem sellPacket(std::move(packet));
+        sellPacket.Read();
+        bot->GetSession()->HandleSellItemOpcode(sellPacket);
+
+        if (botAI->HasCheat(BotCheatMask::gold))
+            bot->SetMoney(moneyBefore);
+
+        uint32 const after = bot->GetItemCount(itemId, false);
+        if (before > after)
+            sold += before - after;
+    }
+
+    if (!sold && reason.empty())
+        reason = "FAILED";
+
+    return sold;
+}
+
 uint32 BuyMatchingVendorItem(Player* bot, uint32 itemId, uint32 requestedCount, std::string& reason)
 {
     if (!bot || !itemId)
@@ -3712,8 +4068,19 @@ void RunInventoryItemActionCommand(Player* requester, ChatMsg replyType, std::st
     std::string const action = ToUpper(Trim(actionValue));
     uint32 itemId = 0;
     uint32 requestedCount = 0;
-    TryParseUint32Field(Trim(itemIdValue), 1, std::numeric_limits<uint32>::max(), itemId);
-    TryParseUint32Field(Trim(countValue), 0, kMaxItemActionCount, requestedCount);
+    if (action == "SELL_GREY" || action == "SELL_VENDOR")
+    {
+        if (Trim(itemIdValue) != "0" || Trim(countValue) != "0")
+        {
+            itemId = std::numeric_limits<uint32>::max();
+            requestedCount = std::numeric_limits<uint32>::max();
+        }
+    }
+    else
+    {
+        TryParseUint32Field(Trim(itemIdValue), 1, std::numeric_limits<uint32>::max(), itemId);
+        TryParseUint32Field(Trim(countValue), 0, kMaxItemActionCount, requestedCount);
+    }
 
     Player* const bot = FindBotByName(requester, trimmedBotName);
     std::string const effectiveBotName = bot ? bot->GetName() : trimmedBotName;
@@ -3746,6 +4113,20 @@ void RunInventoryItemActionCommand(Player* requester, ChatMsg replyType, std::st
             moved = MoveMatchingGuildBankItemsToBags(requester, bot, itemId, requestedCount, reason);
         else if (action == "BUY_ITEM")
             moved = BuyMatchingVendorItem(bot, itemId, requestedCount, reason);
+        else if (action == "SELL_GREY")
+        {
+            if (itemId != 0 || requestedCount != 0)
+                reason = "BAD_REQUEST";
+            else
+                moved = SellGreyBagItems(bot, reason);
+        }
+        else if (action == "SELL_VENDOR")
+        {
+            if (itemId != 0 || requestedCount != 0)
+                reason = "BAD_REQUEST";
+            else
+                moved = SellVendorBagItems(bot, reason);
+        }
         else
             reason = "BAD_ACTION";
     }
@@ -5953,8 +6334,14 @@ bool HandleBridgeOpcode(Player* player, ChatMsg replyType, std::string const& op
 
         uint32 itemId = 0;
         uint32 count = 0;
-        if (!TryParseUint32Field(fields[4], 1, std::numeric_limits<uint32>::max(), itemId) ||
-            !TryParseUint32Field(fields[5], 0, kMaxItemActionCount, count))
+        std::string const itemAction = ToUpper(fields[3]);
+        if (itemAction == "SELL_GREY" || itemAction == "SELL_VENDOR")
+        {
+            if (fields[4] != "0" || fields[5] != "0")
+                return SendProtocolError(player, replyType, normalized, requestType, token, "BAD_NUMBER");
+        }
+        else if (!TryParseUint32Field(fields[4], 1, std::numeric_limits<uint32>::max(), itemId) ||
+                 !TryParseUint32Field(fields[5], 0, kMaxItemActionCount, count))
         {
             return SendProtocolError(player, replyType, normalized, requestType, token, "BAD_NUMBER");
         }

--- a/src/MultiBotBridge.cpp
+++ b/src/MultiBotBridge.cpp
@@ -75,6 +75,7 @@ char const* const kStateFramingCapability = "STATE_FRAMING_V1";
 char const* const kStrategyMutationCapability = "STRATEGY_MUTATION_V1";
 char const* const kOutfitCapability = "OUTFIT_V1";
 char const* const kInventoryCapability = "INVENTORY_V1";
+char const* const kInventoryBulkSellCapability = "INVENTORY_BULK_SELL_V1";
 uint32 constexpr kMaxItemActionCount = 1000;
 
 enum class BridgePayloadStatus
@@ -3826,6 +3827,85 @@ std::array<SkillType, 14> const& GetBridgeCraftProtectionSkills()
     return skills;
 }
 
+using BridgeReferenceLootRows = std::map<uint32, std::vector<std::pair<uint32, uint32>>>;
+
+BridgeReferenceLootRows BuildBridgeReferenceLootRows()
+{
+    BridgeReferenceLootRows rows;
+
+    QueryResult result = WorldDatabase.Query(
+        "SELECT Entry, Item, Reference FROM reference_loot_template");
+    if (!result)
+        return rows;
+
+    do
+    {
+        Field* const fields = result->Fetch();
+        uint32 const entryId = fields[0].Get<uint32>();
+        uint32 const itemId = fields[1].Get<uint32>();
+        uint32 const referenceId = fields[2].Get<uint32>();
+
+        if (entryId)
+            rows[entryId].push_back({itemId, referenceId});
+    } while (result->NextRow());
+
+    return rows;
+}
+
+void AddBridgeReferenceLootOutputs(std::set<uint32> const& initialReferences,
+                                   BridgeReferenceLootRows const& referenceRows,
+                                   std::set<uint32>& itemIds)
+{
+    std::set<uint32> visitedReferences;
+    std::vector<uint32> pendingReferences(initialReferences.begin(), initialReferences.end());
+
+    while (!pendingReferences.empty())
+    {
+        uint32 const referenceId = pendingReferences.back();
+        pendingReferences.pop_back();
+
+        if (!referenceId || !visitedReferences.insert(referenceId).second)
+            continue;
+
+        auto const rowsIt = referenceRows.find(referenceId);
+        if (rowsIt == referenceRows.end())
+            continue;
+
+        for (auto const& row : rowsIt->second)
+        {
+            if (row.first)
+                itemIds.insert(row.first);
+
+            if (row.second && visitedReferences.find(row.second) == visitedReferences.end())
+                pendingReferences.push_back(row.second);
+        }
+    }
+}
+
+void AddBridgeLootTableOutputs(char const* tableName,
+                               BridgeReferenceLootRows const& referenceRows,
+                               std::set<uint32>& itemIds)
+{
+    QueryResult result = WorldDatabase.Query("SELECT Item, Reference FROM {}", tableName);
+    if (!result)
+        return;
+
+    std::set<uint32> references;
+    do
+    {
+        Field* const fields = result->Fetch();
+        uint32 const itemId = fields[0].Get<uint32>();
+        uint32 const referenceId = fields[1].Get<uint32>();
+
+        if (itemId)
+            itemIds.insert(itemId);
+
+        if (referenceId)
+            references.insert(referenceId);
+    } while (result->NextRow());
+
+    AddBridgeReferenceLootOutputs(references, referenceRows, itemIds);
+}
 std::map<uint32, std::set<uint32>> const& GetBridgeCraftOutputsBySkill()
 {
     // The source data is process-wide and immutable for normal runtime use.
@@ -3868,6 +3948,18 @@ std::map<uint32, std::set<uint32>> const& GetBridgeCraftOutputsBySkill()
                 }
             }
         }
+
+        // Prospecting and milling use loot templates instead of
+        // SPELL_EFFECT_CREATE_ITEM(_2). Include every possible output,
+        // following reference_loot_template recursively, in the same
+        // process-wide cache used by SELL_VENDOR.
+        BridgeReferenceLootRows const referenceLootRows = BuildBridgeReferenceLootRows();
+        AddBridgeLootTableOutputs(
+            "prospecting_loot_template", referenceLootRows,
+            outputs[static_cast<uint32>(SKILL_JEWELCRAFTING)]);
+        AddBridgeLootTableOutputs(
+            "milling_loot_template", referenceLootRows,
+            outputs[static_cast<uint32>(SKILL_INSCRIPTION)]);
 
         return outputs;
     }();
@@ -5980,7 +6072,7 @@ bool HandleBridgeOpcode(Player* player, ChatMsg replyType, std::string const& op
             player,
             replyType,
             "CAPS",
-            std::string(kStateFramingCapability) + "," + kStrategyMutationCapability + "," + kOutfitCapability + "," + kInventoryCapability);
+            std::string(kStateFramingCapability) + "," + kStrategyMutationCapability + "," + kOutfitCapability + "," + kInventoryCapability + "," + kInventoryBulkSellCapability);
         return true;
     }
 

--- a/src/MultiBotBridge.cpp
+++ b/src/MultiBotBridge.cpp
@@ -3766,21 +3766,39 @@ void AddBridgeCraftOutputsFromSpellInfo(SpellInfo const* spellInfo, std::set<uin
     }
 }
 
-void AddBridgeCraftOutputsFromSpell(uint32 spellId, std::set<uint32>& itemIds)
+void AddBridgeCraftOutputsFromSpell(uint32 spellId, std::set<uint32>& itemIds,
+                                    std::set<uint32>* visitedSpellIds = nullptr)
 {
-    SpellInfo const* const spellInfo = sSpellMgr->GetSpellInfo(spellId);
-    if (!spellInfo)
-        return;
+    std::set<uint32> visitedSpells;
+    std::vector<uint32> pendingSpells;
+    pendingSpells.push_back(spellId);
 
-    AddBridgeCraftOutputsFromSpellInfo(spellInfo, itemIds);
-
-    // One triggered-spell level, matching the audited Playerbots pattern.
-    // Only created outputs are recorded; reagents are never treated as crafts.
-    for (uint8 i = 0; i < MAX_SPELL_EFFECTS; ++i)
+    while (!pendingSpells.empty())
     {
-        uint32 const triggerSpell = spellInfo->Effects[i].TriggerSpell;
-        if (triggerSpell)
-            AddBridgeCraftOutputsFromSpellInfo(sSpellMgr->GetSpellInfo(triggerSpell), itemIds);
+        uint32 const currentSpellId = pendingSpells.back();
+        pendingSpells.pop_back();
+
+        if (!currentSpellId || !visitedSpells.insert(currentSpellId).second)
+            continue;
+
+        SpellInfo const* const spellInfo = sSpellMgr->GetSpellInfo(currentSpellId);
+        if (!spellInfo)
+            continue;
+
+        if (visitedSpellIds)
+            visitedSpellIds->insert(currentSpellId);
+
+        AddBridgeCraftOutputsFromSpellInfo(spellInfo, itemIds);
+
+        // Follow the complete TriggerSpell graph. The visited set prevents
+        // cycles while preserving every concrete create-item output reachable
+        // from a profession or recipe spell.
+        for (uint8 i = 0; i < MAX_SPELL_EFFECTS; ++i)
+        {
+            uint32 const triggerSpell = spellInfo->Effects[i].TriggerSpell;
+            if (triggerSpell && visitedSpells.find(triggerSpell) == visitedSpells.end())
+                pendingSpells.push_back(triggerSpell);
+        }
     }
 }
 
@@ -3852,6 +3870,29 @@ BridgeReferenceLootRows BuildBridgeReferenceLootRows()
     return rows;
 }
 
+BridgeReferenceLootRows BuildBridgeLootTableRows(char const* tableName)
+{
+    BridgeReferenceLootRows rows;
+
+    QueryResult result = WorldDatabase.Query(
+        "SELECT Entry, Item, Reference FROM {}", tableName);
+    if (!result)
+        return rows;
+
+    do
+    {
+        Field* const fields = result->Fetch();
+        uint32 const entryId = fields[0].Get<uint32>();
+        uint32 const itemId = fields[1].Get<uint32>();
+        uint32 const referenceId = fields[2].Get<uint32>();
+
+        if (entryId)
+            rows[entryId].push_back({itemId, referenceId});
+    } while (result->NextRow());
+
+    return rows;
+}
+
 void AddBridgeReferenceLootOutputs(std::set<uint32> const& initialReferences,
                                    BridgeReferenceLootRows const& referenceRows,
                                    std::set<uint32>& itemIds)
@@ -3882,6 +3923,40 @@ void AddBridgeReferenceLootOutputs(std::set<uint32> const& initialReferences,
     }
 }
 
+void AddBridgeLootEntryOutputs(uint32 entryId,
+                               BridgeReferenceLootRows const& lootRows,
+                               BridgeReferenceLootRows const& referenceRows,
+                               std::set<uint32>& itemIds)
+{
+    auto const rowsIt = lootRows.find(entryId);
+    if (!entryId || rowsIt == lootRows.end())
+        return;
+
+    std::set<uint32> references;
+    for (auto const& row : rowsIt->second)
+    {
+        if (row.first)
+            itemIds.insert(row.first);
+
+        if (row.second)
+            references.insert(row.second);
+    }
+
+    AddBridgeReferenceLootOutputs(references, referenceRows, itemIds);
+}
+
+void AddBridgeCraftAndSpellLootOutputs(uint32 spellId,
+                                       BridgeReferenceLootRows const& spellLootRows,
+                                       BridgeReferenceLootRows const& referenceRows,
+                                       std::set<uint32>& itemIds)
+{
+    std::set<uint32> visitedSpellIds;
+    AddBridgeCraftOutputsFromSpell(spellId, itemIds, &visitedSpellIds);
+
+    for (uint32 const visitedSpellId : visitedSpellIds)
+        AddBridgeLootEntryOutputs(visitedSpellId, spellLootRows, referenceRows, itemIds);
+}
+
 void AddBridgeLootTableOutputs(char const* tableName,
                                BridgeReferenceLootRows const& referenceRows,
                                std::set<uint32>& itemIds)
@@ -3910,10 +3985,14 @@ std::map<uint32, std::set<uint32>> const& GetBridgeCraftOutputsBySkill()
 {
     // The source data is process-wide and immutable for normal runtime use.
     // Function-local static initialization is thread-safe, so the expensive
-    // SkillLineAbility and item-template scans run only on the first request.
+    // SkillLineAbility, item-template, and loot-table scans run only once.
     static std::map<uint32, std::set<uint32>> const outputsBySkill = []()
     {
         std::map<uint32, std::set<uint32>> outputs;
+
+        BridgeReferenceLootRows const referenceLootRows = BuildBridgeReferenceLootRows();
+        BridgeReferenceLootRows const spellLootRows =
+            BuildBridgeLootTableRows("spell_loot_template");
 
         for (SkillType const skill : GetBridgeCraftProtectionSkills())
         {
@@ -3923,13 +4002,15 @@ std::map<uint32, std::set<uint32>> const& GetBridgeCraftOutputsBySkill()
             for (SkillLineAbilityEntry const* const ability : GetSkillLineAbilitiesBySkillLine(skillId))
             {
                 if (ability)
-                    AddBridgeCraftOutputsFromSpell(ability->Spell, skillOutputs);
+                    AddBridgeCraftAndSpellLootOutputs(
+                        ability->Spell, spellLootRows, referenceLootRows, skillOutputs);
             }
         }
 
         // Conservative recipe fallback audited from Playerbots. Scan the item
         // template store once, then attach each recognized recipe output to the
-        // corresponding profession set.
+        // corresponding profession set. Random spell-loot outputs and every
+        // reachable TriggerSpell are covered by the same helper.
         std::vector<ItemTemplate*> const* const itemTemplates = sObjectMgr->GetItemTemplateStoreFast();
         if (itemTemplates)
         {
@@ -3944,16 +4025,15 @@ std::map<uint32, std::set<uint32>> const& GetBridgeCraftOutputsBySkill()
                 {
                     uint32 const spellId = recipe->Spells[i].SpellId;
                     if (spellId)
-                        AddBridgeCraftOutputsFromSpell(spellId, outputIt->second);
+                        AddBridgeCraftAndSpellLootOutputs(
+                            spellId, spellLootRows, referenceLootRows, outputIt->second);
                 }
             }
         }
 
-        // Prospecting, milling, and disenchanting use loot templates instead of
-        // SPELL_EFFECT_CREATE_ITEM(_2). Include every possible output,
-        // following reference_loot_template recursively, in the same
-        // process-wide cache used by SELL_VENDOR.
-        BridgeReferenceLootRows const referenceLootRows = BuildBridgeReferenceLootRows();
+        // Prospecting, milling, and disenchanting use dedicated loot templates.
+        // Include every possible output and follow reference_loot_template
+        // recursively in the same process-wide cache used by SELL_VENDOR.
         AddBridgeLootTableOutputs(
             "prospecting_loot_template", referenceLootRows,
             outputs[static_cast<uint32>(SKILL_JEWELCRAFTING)]);

--- a/src/MultiBotBridge.cpp
+++ b/src/MultiBotBridge.cpp
@@ -3614,9 +3614,9 @@ uint32 MoveMatchingGuildBankItemsToBags(Player* requester, Player* bot, uint32 i
     return moved;
 }
 
-bool IsBridgeSellGreyCandidate(Item* item)
+bool IsBridgeSellGreyCandidate(PlayerbotAI* botAI, Item* item)
 {
-    if (!item)
+    if (!botAI || !item)
         return false;
 
     ItemTemplate const* const proto = item->GetTemplate();
@@ -3631,6 +3631,17 @@ bool IsBridgeSellGreyCandidate(Item* item)
 
     // Keep the same explicit protection already enforced by the addon.
     if (item->GetEntry() == 6948)
+        return false;
+
+    // An active quest objective can require a poor-quality sellable item whose
+    // template is not ITEM_CLASS_QUEST. Reuse Playerbots' audited item-usage
+    // classification and keep the item when it is currently needed for a quest.
+    AiObjectContext* const context = botAI->GetAiObjectContext();
+    if (!context)
+        return false;
+
+    ItemUsage const usage = context->GetValue<ItemUsage>("item usage", item->GetEntry())->Get();
+    if (usage == ITEM_USAGE_QUEST)
         return false;
 
     return true;
@@ -3654,9 +3665,9 @@ Creature* FindNearbyInteractiveVendor(Player* bot)
     return nullptr;
 }
 
-void CollectBridgeSellGreyCandidate(Item* item, std::vector<ObjectGuid>& itemGuids)
+void CollectBridgeSellGreyCandidate(PlayerbotAI* botAI, Item* item, std::vector<ObjectGuid>& itemGuids)
 {
-    if (IsBridgeSellGreyCandidate(item))
+    if (IsBridgeSellGreyCandidate(botAI, item))
         itemGuids.push_back(item->GetGUID());
 }
 
@@ -3675,12 +3686,19 @@ uint32 SellGreyBagItems(Player* bot, std::string& reason)
         return 0;
     }
 
+    PlayerbotAI* const botAI = GetBotAI(bot);
+    if (!botAI || !botAI->GetAiObjectContext())
+    {
+        reason = "FAILED";
+        return 0;
+    }
+
     std::vector<ObjectGuid> itemGuids;
 
     // Snapshot candidate GUIDs before invoking the sell handler so inventory
     // mutations cannot invalidate the bag iteration.
     for (uint8 slot = INVENTORY_SLOT_ITEM_START; slot < INVENTORY_SLOT_ITEM_END; ++slot)
-        CollectBridgeSellGreyCandidate(bot->GetItemByPos(INVENTORY_SLOT_BAG_0, slot), itemGuids);
+        CollectBridgeSellGreyCandidate(botAI, bot->GetItemByPos(INVENTORY_SLOT_BAG_0, slot), itemGuids);
 
     for (uint8 bag = INVENTORY_SLOT_BAG_START; bag < INVENTORY_SLOT_BAG_END; ++bag)
     {
@@ -3689,7 +3707,7 @@ uint32 SellGreyBagItems(Player* bot, std::string& reason)
             continue;
 
         for (uint8 slot = 0; slot < pBag->GetBagSize(); ++slot)
-            CollectBridgeSellGreyCandidate(pBag->GetItemByPos(slot), itemGuids);
+            CollectBridgeSellGreyCandidate(botAI, pBag->GetItemByPos(slot), itemGuids);
     }
 
     if (itemGuids.empty())
@@ -3698,13 +3716,12 @@ uint32 SellGreyBagItems(Player* bot, std::string& reason)
         return 0;
     }
 
-    PlayerbotAI* const botAI = GetBotAI(bot);
     uint32 sold = 0;
 
     for (ObjectGuid const itemGuid : itemGuids)
     {
         Item* const item = bot->GetItemByGuid(itemGuid);
-        if (!IsBridgeSellGreyCandidate(item))
+        if (!IsBridgeSellGreyCandidate(botAI, item))
             continue;
 
         uint32 const itemId = item->GetEntry();
@@ -3720,7 +3737,7 @@ uint32 SellGreyBagItems(Player* bot, std::string& reason)
 
         // Match Playerbots SellAction semantics when the gold cheat is active,
         // without calling SellAction/TellMaster and therefore without chat spam.
-        if (botAI && botAI->HasCheat(BotCheatMask::gold))
+        if (botAI->HasCheat(BotCheatMask::gold))
             bot->SetMoney(moneyBefore);
 
         uint32 const after = bot->GetItemCount(itemId, false);
@@ -3787,13 +3804,9 @@ uint32 GetBridgeRecipeSkillId(ItemTemplate const* recipe)
     }
 }
 
-std::set<uint32> BuildBridgeCraftProtectedItemIds(PlayerbotAI* botAI)
+std::array<SkillType, 14> const& GetBridgeCraftProtectionSkills()
 {
-    std::set<uint32> itemIds;
-    if (!botAI)
-        return itemIds;
-
-    std::array<SkillType, 14> const skills = {
+    static std::array<SkillType, 14> const skills = {
         SKILL_ALCHEMY,
         SKILL_ENCHANTING,
         SKILL_SKINNING,
@@ -3810,36 +3823,74 @@ std::set<uint32> BuildBridgeCraftProtectedItemIds(PlayerbotAI* botAI)
         SKILL_JEWELCRAFTING
     };
 
-    for (SkillType const skill : skills)
+    return skills;
+}
+
+std::map<uint32, std::set<uint32>> const& GetBridgeCraftOutputsBySkill()
+{
+    // The source data is process-wide and immutable for normal runtime use.
+    // Function-local static initialization is thread-safe, so the expensive
+    // SkillLineAbility and item-template scans run only on the first request.
+    static std::map<uint32, std::set<uint32>> const outputsBySkill = []()
+    {
+        std::map<uint32, std::set<uint32>> outputs;
+
+        for (SkillType const skill : GetBridgeCraftProtectionSkills())
+        {
+            uint32 const skillId = static_cast<uint32>(skill);
+            std::set<uint32>& skillOutputs = outputs[skillId];
+
+            for (SkillLineAbilityEntry const* const ability : GetSkillLineAbilitiesBySkillLine(skillId))
+            {
+                if (ability)
+                    AddBridgeCraftOutputsFromSpell(ability->Spell, skillOutputs);
+            }
+        }
+
+        // Conservative recipe fallback audited from Playerbots. Scan the item
+        // template store once, then attach each recognized recipe output to the
+        // corresponding profession set.
+        std::vector<ItemTemplate*> const* const itemTemplates = sObjectMgr->GetItemTemplateStoreFast();
+        if (itemTemplates)
+        {
+            for (ItemTemplate const* const recipe : *itemTemplates)
+            {
+                uint32 const skillId = GetBridgeRecipeSkillId(recipe);
+                auto const outputIt = outputs.find(skillId);
+                if (!skillId || outputIt == outputs.end())
+                    continue;
+
+                for (uint8 i = 0; i < MAX_ITEM_PROTO_SPELLS; ++i)
+                {
+                    uint32 const spellId = recipe->Spells[i].SpellId;
+                    if (spellId)
+                        AddBridgeCraftOutputsFromSpell(spellId, outputIt->second);
+                }
+            }
+        }
+
+        return outputs;
+    }();
+
+    return outputsBySkill;
+}
+
+std::set<uint32> BuildBridgeCraftProtectedItemIds(PlayerbotAI* botAI)
+{
+    std::set<uint32> itemIds;
+    if (!botAI)
+        return itemIds;
+
+    std::map<uint32, std::set<uint32>> const& outputsBySkill = GetBridgeCraftOutputsBySkill();
+
+    for (SkillType const skill : GetBridgeCraftProtectionSkills())
     {
         if (!botAI->HasSkill(skill))
             continue;
 
-        for (SkillLineAbilityEntry const* const ability :
-             GetSkillLineAbilitiesBySkillLine(static_cast<uint32>(skill)))
-        {
-            if (ability)
-                AddBridgeCraftOutputsFromSpell(ability->Spell, itemIds);
-        }
-    }
-
-    // Conservative recipe fallback audited from Playerbots.
-    std::vector<ItemTemplate*> const* const itemTemplates = sObjectMgr->GetItemTemplateStoreFast();
-    if (!itemTemplates)
-        return itemIds;
-
-    for (ItemTemplate const* const recipe : *itemTemplates)
-    {
-        uint32 const skillId = GetBridgeRecipeSkillId(recipe);
-        if (!skillId || !botAI->HasSkill(static_cast<SkillType>(skillId)))
-            continue;
-
-        for (uint8 i = 0; i < MAX_ITEM_PROTO_SPELLS; ++i)
-        {
-            uint32 const spellId = recipe->Spells[i].SpellId;
-            if (spellId)
-                AddBridgeCraftOutputsFromSpell(spellId, itemIds);
-        }
+        auto const outputIt = outputsBySkill.find(static_cast<uint32>(skill));
+        if (outputIt != outputsBySkill.end())
+            itemIds.insert(outputIt->second.begin(), outputIt->second.end());
     }
 
     return itemIds;

--- a/src/MultiBotBridge.cpp
+++ b/src/MultiBotBridge.cpp
@@ -3949,7 +3949,7 @@ std::map<uint32, std::set<uint32>> const& GetBridgeCraftOutputsBySkill()
             }
         }
 
-        // Prospecting and milling use loot templates instead of
+        // Prospecting, milling, and disenchanting use loot templates instead of
         // SPELL_EFFECT_CREATE_ITEM(_2). Include every possible output,
         // following reference_loot_template recursively, in the same
         // process-wide cache used by SELL_VENDOR.
@@ -3960,6 +3960,9 @@ std::map<uint32, std::set<uint32>> const& GetBridgeCraftOutputsBySkill()
         AddBridgeLootTableOutputs(
             "milling_loot_template", referenceLootRows,
             outputs[static_cast<uint32>(SKILL_INSCRIPTION)]);
+        AddBridgeLootTableOutputs(
+            "disenchant_loot_template", referenceLootRows,
+            outputs[static_cast<uint32>(SKILL_ENCHANTING)]);
 
         return outputs;
     }();
@@ -4211,13 +4214,11 @@ void RunInventoryItemActionCommand(Player* requester, ChatMsg replyType, std::st
     std::string const action = ToUpper(Trim(actionValue));
     uint32 itemId = 0;
     uint32 requestedCount = 0;
+    bool sellParamsInvalid = false;
     if (action == "SELL_GREY" || action == "SELL_VENDOR")
     {
         if (Trim(itemIdValue) != "0" || Trim(countValue) != "0")
-        {
-            itemId = std::numeric_limits<uint32>::max();
-            requestedCount = std::numeric_limits<uint32>::max();
-        }
+            sellParamsInvalid = true;
     }
     else
     {
@@ -4258,14 +4259,14 @@ void RunInventoryItemActionCommand(Player* requester, ChatMsg replyType, std::st
             moved = BuyMatchingVendorItem(bot, itemId, requestedCount, reason);
         else if (action == "SELL_GREY")
         {
-            if (itemId != 0 || requestedCount != 0)
+            if (sellParamsInvalid)
                 reason = "BAD_REQUEST";
             else
                 moved = SellGreyBagItems(bot, reason);
         }
         else if (action == "SELL_VENDOR")
         {
-            if (itemId != 0 || requestedCount != 0)
+            if (sellParamsInvalid)
                 reason = "BAD_REQUEST";
             else
                 moved = SellVendorBagItems(bot, reason);


### PR DESCRIPTION
Adds the bridge-first SELL_VENDOR inventory action for bot inventory management without invoking Playerbots SellAction or emitting TellMaster sale messages.

Uses AzerothCore's native HandleSellItemOpcode as the final sell authority and applies a fail-safe candidate filter before selling. The filter preserves quest/key items, Hearthstone, projectiles/ammunition, items signed as crafted by the bot, conservative profession craft outputs, and every item not classified by Playerbots as ITEM_USAGE_VENDOR or ITEM_USAGE_AH.

The implementation preserves Playerbots gold-cheat semantics, snapshots item GUIDs before bag mutation, reports the real quantity sold, and leaves SELL_GREY unchanged.

mod-playerbots remains strictly read-only. Build validated with 3 succeeded / 0 failed. In-game tests confirmed successful sales without chat spam and protection of profession tools, Hearthstone and ammunition. Dedicated runtime testing of crafted-item protection is deferred until an appropriate crafted item is available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Nouvelles fonctionnalités**
  - Ajout de la vente groupée des objets gris admissibles auprès d’un vendeur proche.
  - Ajout de la vente des objets classés comme vendables ou destinés à l’hôtel des ventes.
  - Les opérations indiquent la quantité d’objets vendus et signalent les éventuelles erreurs.

- **Améliorations**
  - Les objets de quête, clés, Hearthstone, projectiles et objets fabriqués protégés sont automatiquement exclus.
  - Des vérifications renforcées préviennent les ventes accidentelles ou non valides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->