### PR TITLE
Add ENCHANT_TRADE_V1 native enchanting trade service

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,22 @@ Server -> Addon:  MBOT STRATEGY_ACK~<scope>~<target>~<token>~<stateScope>~<match
 
 Addon  -> Server: MBOT GET~WEAPON_ENCHANT~<botName>~<token>
 Server -> Addon:  MBOT WEAPON_ENCHANT~<token>~<botName>~<status>~<mhItem>~<mhEnchant>~<mhDuration>~<ohItem>~<ohEnchant>~<ohDuration>
+
+Addon  -> Server: MBOT RUN~GROUP_ROLL~<token>~NORMAL
+Addon  -> Server: MBOT RUN~GROUP_ROLL~<token>~ITEM~<encodedItemLink>
+Server -> Addon:  MBOT GROUP_ROLL_ACK~<token>~<status>~<mode>~<scope>~<matched>~<invoked>~<reason>
+
+Addon  -> Server: MBOT GET~ENCHANT_TRADE~<botName>~<token>
+Server -> Addon:  MBOT ENCHANT_TRADE_BEGIN~<botName>~<token>~<status>~<reason>~<skill>~<maxSkill>
+Server -> Addon:  MBOT ENCHANT_TRADE_ITEM~<botName>~<token>~<spellId>~<difficulty>~<available>~<hasTools>
+Server -> Addon:  MBOT ENCHANT_TRADE_MATERIAL~<botName>~<token>~<spellId>~<itemId>~<required>~<available>
+Server -> Addon:  MBOT ENCHANT_TRADE_END~<botName>~<token>~<status>~<reason>~<count>
+
+Addon  -> Server: MBOT RUN~ENCHANT_TRADE~<botName>~<token>~<spellId>
+Server -> Addon:  MBOT ENCHANT_TRADE_RESULT~<botName>~<token>~<spellId>~<status>~<reason>~<accepted>
 ```
+
+Current capability negotiation includes `STATE_FRAMING_V1`, `STRATEGY_MUTATION_V1`, `OUTFIT_V1`, `INVENTORY_V1`, `INVENTORY_BULK_SELL_V1`, `INVENTORY_OPEN_V1`, `GROUP_ROLL_V1` and `ENCHANT_TRADE_V1`.
 
 The exact payloads are consumed internally by the MultiBot addon.
 
@@ -353,7 +368,11 @@ The bridge enforces the following input rules before any endpoint is called:
 - strict `%XX` field decoding;
 - rejection of control characters;
 - a maximum `ITEM_ACTION` count of 1000, while `0` keeps its existing
-  endpoint-specific meaning.
+  endpoint-specific meaning;
+- Group Roll item links are bounded to 160 characters and must contain a valid item-link marker before execution;
+- Group Roll requests are rate-limited per requester (4 requests per 2-second window in the current implementation), and execution is restricted to bridge-visible bots in the requester's actual party/raid with Playerbots security revalidation.
+- Enchant Trade list/run requests are rate-limited per requester (4 requests per 2-second window), require an exact controllable bot name and token, and accept only a positive numeric spell ID for execution.
+- Enchant Trade execution revalidates Playerbots security, active session/state, Enchanting skill, known active Enchanting spell identity, required tools/reagents, the exact current Trade partner and the requester's `TRADE_SLOT_NONTRADED` item before Core spell preparation.
 
 Malformed bridge requests are consumed and answered with:
 
@@ -442,8 +461,24 @@ should not be assumed to be generically fragmented by this capability.
     <td>Refresh available talent spec templates without automatic chat parsing.</td>
   </tr>
   <tr>
-    <td><code>GET~INVENTORY</code></td>
-    <td>Refresh inventory data with item links and icons.</td>
+    <td><code>GET~INVENTORY</code> / <code>INVENTORY_V1</code></td>
+    <td>Refresh inventory data natively through the bridge with item links and icons.</td>
+  </tr>
+  <tr>
+    <td><code>RUN~ITEM_ACTION</code> — <code>SELL_VENDOR</code> / <code>SELL_GREY</code></td>
+    <td>Run bounded bulk-sell actions after bot/security/rate-limit validation. <code>SELL_VENDOR</code> is the normal bridge-first Sell Vendor path; further SELL_GREY project work is explicitly deferred.</td>
+  </tr>
+  <tr>
+    <td><code>RUN~ITEM_ACTION</code> — <code>OPEN_ITEMS</code></td>
+    <td>Run the negotiated <code>INVENTORY_OPEN_V1</code> residual open-items path, revalidating session, controllability and the selected openable item before using the native open-item opcode.</td>
+  </tr>
+  <tr>
+    <td><code>RUN~GROUP_ROLL</code> / <code>GROUP_ROLL_ACK</code></td>
+    <td>Run normal or item-linked group rolls through <code>GROUP_ROLL_V1</code>; execution is bounded to bridge-visible, controllable bots in the requester's actual party/raid and is rate-limited per requester.</td>
+  </tr>
+  <tr>
+    <td><code>GET~ENCHANT_TRADE</code> / <code>RUN~ENCHANT_TRADE</code></td>
+    <td>Expose and execute the negotiated <code>ENCHANT_TRADE_V1</code> Enchanting Trade Service. The bridge lists only known valid Enchanting spells and their material/tool availability, then executes one validated numeric spell ID against the requester's native non-traded Trade item.</td>
   </tr>
   <tr>
     <td><code>GET~BANK</code></td>
@@ -499,7 +534,7 @@ should not be assumed to be generically fragmented by this capability.
   </tr>
   <tr>
     <td><code>RUN~ITEM_ACTION</code></td>
-    <td>Run whitelisted inventory item actions such as bank deposit, bank withdraw, guild bank deposit, guild bank withdraw and vendor buy.</td>
+    <td>Run whitelisted inventory actions including bank deposit/withdraw, guild bank deposit/withdraw, vendor buy, bulk sell and residual open-items operations. Each action has endpoint-specific validation; this is not a generic item-command executor.</td>
   </tr>
   <tr>
     <td><code>RUN~OUTFIT</code></td>
@@ -553,9 +588,15 @@ nc ?
 ss ?
 ```
 
-The bridge only replaces the automatic data-refresh paths used by the addon UI.
+The bridge replaces migrated automatic data-refresh paths and selected gameplay write paths with explicit, whitelisted contracts. It is intentionally **not** a generic Playerbots command executor.
 
 Formation selection and inspection are also bridge-first. `RUN~FORMATION` applies a validated formation across the whole current party or raid, while `GET~FORMATIONS` reads the effective value from each controllable bot. Neither path requires PARTY, RAID, whisper or `TellMaster` output. The `GROUP` scope intentionally covers the complete party or raid; individual raid subgroups are not targeted.
+
+## Enchanting Trade Service
+
+The Enchanting Trade Service is intentionally narrower than a generic cast endpoint. `ENCHANT_TRADE_V1` discovers only spells the selected bot actually knows that belong to the Enchanting skill line and contain a valid non-soulbinding `SPELL_EFFECT_ENCHANT_ITEM`. Execution accepts only the numeric spell ID, revalidates the requester/bot Trade relationship and `TRADE_SLOT_NONTRADED`, then uses native `SpellCastTargets::SetTradeItemTarget()` and Core `Spell::prepare()`. The normal Trade accept path performs Core validation again before the enchant is finalized.
+
+Runtime validation on 2026-08-14 confirmed list retrieval, reagent/tool status, native Trade-window targeting and a real item enchant. No generic Playerbots command/cast executor or automatic chat path is exposed by this capability.
 
 ## Warlock strategy selectors and stone switching
 
@@ -572,6 +613,24 @@ Firestone/Spellstone switching needs one additional bridge-side guard because Pl
 No Firestone/Spellstone enchant ID is hardcoded by this switch path, and `mod-playerbots` does not need to be modified.
 
 For targeted verification, `GET~WEAPON_ENCHANT` / `WEAPON_ENCHANT` exposes an on-demand diagnostic snapshot of the equipped weapon temporary-enchant state. It checks bot visibility/control security and applies a 500 ms per-requester rate limit. It is not used for automatic polling.
+
+The endpoint and switching implementation remain present, while the project's final real Firestone/Spellstone `TEMP_ENCHANTMENT_SLOT` revalidation is intentionally deferred until the end of the normal roadmap.
+
+---
+
+# Current Development Baseline
+
+Documentation synchronized on **2026-08-14** against:
+
+- addon `main`: `106074c3c93f80812f73af27e746860c7c8a4dcf` (PR #61, Group Roll UI);
+- bridge `main`: `210bd1f4f6597fe4f0691ec729ec4904ebe2d463` (PR #26, Group Roll support).
+
+Recent bridge-first milestones include `OUTFIT_V1`, `INVENTORY_V1`, hardened bank/guild-bank/vendor-buy item actions, `INVENTORY_BULK_SELL_V1`, `INVENTORY_OPEN_V1`, `GROUP_ROLL_V1` and the runtime-validated `ENCHANT_TRADE_V1` Enchanting Trade Service.
+
+The current PR candidate adds `ENCHANT_TRADE_V1` on top of the Group Roll main baseline. Runtime validation on 2026-08-14 confirmed known-enchant listing, native Trade-slot execution and a real item enchant with no generic cast/chat executor.
+
+The next normal roadmap item is **item-specific loot-rule add/remove**. Deferred work that must not interrupt that sequence includes the SELL_GREY/core-API follow-up and final Firestone/Spellstone TEMP_ENCHANT revalidation.
+
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -338,8 +338,8 @@ Server -> Addon:  MBOT GROUP_ROLL_ACK~<token>~<status>~<mode>~<scope>~<matched>~
 
 Addon  -> Server: MBOT GET~ENCHANT_TRADE~<botName>~<token>
 Server -> Addon:  MBOT ENCHANT_TRADE_BEGIN~<botName>~<token>~<status>~<reason>~<skill>~<maxSkill>
-Server -> Addon:  MBOT ENCHANT_TRADE_ITEM~<botName>~<token>~<spellId>~<difficulty>~<available>~<hasTools>
-Server -> Addon:  MBOT ENCHANT_TRADE_MATERIAL~<botName>~<token>~<spellId>~<itemId>~<required>~<available>
+Server -> Addon:  MBOT ENCHANT_TRADE_ITEM~<botName>~<token>~<spellId>~<difficulty>~<available>~<hasTools>~<materialCount>
+Server -> Addon:  MBOT ENCHANT_TRADE_MATERIAL~<botName>~<token>~<spellId>~<materialIndex>~<itemId>~<required>~<available>
 Server -> Addon:  MBOT ENCHANT_TRADE_END~<botName>~<token>~<status>~<reason>~<count>
 
 Addon  -> Server: MBOT RUN~ENCHANT_TRADE~<botName>~<token>~<spellId>
@@ -372,6 +372,7 @@ The bridge enforces the following input rules before any endpoint is called:
 - Group Roll item links are bounded to 160 characters and must contain a valid item-link marker before execution;
 - Group Roll requests are rate-limited per requester (4 requests per 2-second window in the current implementation), and execution is restricted to bridge-visible bots in the requester's actual party/raid with Playerbots security revalidation.
 - Enchant Trade list/run requests are rate-limited per requester (4 requests per 2-second window), require an exact controllable bot name and token, and accept only a positive numeric spell ID for execution.
+- Enchant Trade list framing declares a per-entry material count and 1-based material indexes; the addon rejects missing, duplicate or out-of-range material frames before caching a list.
 - Enchant Trade execution revalidates Playerbots security, active session/state, Enchanting skill, known active Enchanting spell identity, required tools/reagents, the exact current Trade partner and the requester's `TRADE_SLOT_NONTRADED` item before Core spell preparation.
 
 Malformed bridge requests are consumed and answered with:

--- a/README.md
+++ b/README.md
@@ -596,6 +596,8 @@ Formation selection and inspection are also bridge-first. `RUN~FORMATION` applie
 
 The Enchanting Trade Service is intentionally narrower than a generic cast endpoint. `ENCHANT_TRADE_V1` discovers only spells the selected bot actually knows that belong to the Enchanting skill line and contain a valid non-soulbinding `SPELL_EFFECT_ENCHANT_ITEM`. Execution accepts only the numeric spell ID, revalidates the requester/bot Trade relationship and `TRADE_SLOT_NONTRADED`, then uses native `SpellCastTargets::SetTradeItemTarget()` and Core `Spell::prepare()`. The normal Trade accept path performs Core validation again before the enchant is finalized.
 
+Discovery responses are capped at 256 enchantment entries. `ENCHANT_TRADE_END` reports the number of `ENCHANT_TRADE_ITEM` entries actually sent after that cap and per-packet budget checks.
+
 Runtime validation on 2026-08-14 confirmed list retrieval, reagent/tool status, native Trade-window targeting and a real item enchant. No generic Playerbots command/cast executor or automatic chat path is exposed by this capability.
 
 ## Warlock strategy selectors and stone switching

--- a/src/MultiBotBridge.cpp
+++ b/src/MultiBotBridge.cpp
@@ -4793,7 +4793,7 @@ void SendEnchantTradePackets(Player* requester, ChatMsg replyType, std::string c
     std::string const trimmedBotName = Trim(botName);
     std::string const token = Trim(requestToken);
     Player* const bot = FindBotByName(requester, trimmedBotName);
-    std::string const effectiveBotName = bot ? bot->GetName() : "";
+    std::string const effectiveBotName = bot ? bot->GetName() : trimmedBotName;
     std::string reason = "OK";
 
     if (!ConsumeEnchantTradeRateLimit(requester))
@@ -4936,7 +4936,7 @@ void RunEnchantTradeCommand(Player* requester, ChatMsg replyType, std::string co
     TryParseUint32Field(Trim(spellIdValue), 1, std::numeric_limits<uint32>::max(), spellId);
 
     Player* const bot = FindBotByName(requester, trimmedBotName);
-    std::string const effectiveBotName = bot ? bot->GetName() : "";
+    std::string const effectiveBotName = bot ? bot->GetName() : trimmedBotName;
     std::string reason = "OK";
     bool accepted = false;
 
@@ -4953,10 +4953,25 @@ void RunEnchantTradeCommand(Player* requester, ChatMsg replyType, std::string co
             SpellCastTargets targets;
             targets.SetTradeItemTarget(bot);
 
-            Spell* const spell = new Spell(bot, spellInfo, TRIGGERED_NONE);
-            SpellCastResult const result = spell->prepare(&targets);
+            // Mirror the native TradeHandler validation path without preparing a
+            // heap-allocated Spell here. The Core owns final spell preparation
+            // when the normal trade is accepted.
+            Spell spell(bot, spellInfo, TRIGGERED_FULL_MASK);
+            spell.m_targets = targets;
+            SpellCastResult const result = spell.CheckCast(true);
             reason = GetSpellCastFailureReason(result);
-            accepted = result == SPELL_CAST_OK;
+
+            if (result == SPELL_CAST_OK)
+            {
+                TradeData* const botTrade = bot->GetTradeData();
+                if (!botTrade)
+                    reason = "NO_TRADE";
+                else
+                {
+                    botTrade->SetSpell(spellId);
+                    accepted = true;
+                }
+            }
         }
     }
 

--- a/src/MultiBotBridge.cpp
+++ b/src/MultiBotBridge.cpp
@@ -4836,17 +4836,21 @@ void SendEnchantTradePackets(Player* requester, ChatMsg replyType, std::string c
                 << kFieldSeparator << entry.spellId
                 << kFieldSeparator << UrlEncodeField(entry.difficulty)
                 << kFieldSeparator << entry.available
-                << kFieldSeparator << entry.hasTools;
+                << kFieldSeparator << entry.hasTools
+                << kFieldSeparator << entry.materials.size();
             if (!IsAddonPacketWithinBudget("ENCHANT_TRADE_ITEM", payload.str()))
                 continue;
 
             SendAddonPacket(requester, replyType, "ENCHANT_TRADE_ITEM", payload.str());
+            uint32 materialIndex = 0;
             for (EnchantTradeMaterialData const& material : entry.materials)
             {
+                ++materialIndex;
                 std::ostringstream materialPayload;
                 materialPayload << UrlEncodeField(effectiveBotName)
                     << kFieldSeparator << token
                     << kFieldSeparator << entry.spellId
+                    << kFieldSeparator << materialIndex
                     << kFieldSeparator << material.itemId
                     << kFieldSeparator << material.required
                     << kFieldSeparator << material.available;

--- a/src/MultiBotBridge.cpp
+++ b/src/MultiBotBridge.cpp
@@ -77,6 +77,9 @@ std::size_t constexpr kItemActionRateLimit = 24;
 std::chrono::milliseconds constexpr kItemActionRateWindow(2000);
 std::size_t constexpr kGroupRollRateLimit = 4;
 std::chrono::milliseconds constexpr kGroupRollRateWindow(2000);
+std::size_t constexpr kEnchantTradeRateLimit = 4;
+std::chrono::milliseconds constexpr kEnchantTradeRateWindow(2000);
+std::size_t constexpr kMaxEnchantTradeEntries = 256;
 std::size_t constexpr kMaxGroupRollItemLinkLength = 160;
 char const* const kStateFramingCapability = "STATE_FRAMING_V1";
 char const* const kStrategyMutationCapability = "STRATEGY_MUTATION_V1";
@@ -85,6 +88,7 @@ char const* const kInventoryCapability = "INVENTORY_V1";
 char const* const kInventoryBulkSellCapability = "INVENTORY_BULK_SELL_V1";
 char const* const kInventoryOpenCapability = "INVENTORY_OPEN_V1";
 char const* const kGroupRollCapability = "GROUP_ROLL_V1";
+char const* const kEnchantTradeCapability = "ENCHANT_TRADE_V1";
 uint32 constexpr kMaxItemActionCount = 1000;
 
 enum class BridgePayloadStatus
@@ -110,6 +114,8 @@ void SendTrainerPackets(Player* requester, ChatMsg replyType, std::string const&
 void RunOutfitCommand(Player* requester, ChatMsg replyType, std::string const& botName, std::string const& requestToken, std::string const& encodedSuffix, std::string const& persistToken);
 void RunTrainerLearnCommand(Player* requester, ChatMsg replyType, std::string const& botName, std::string const& requestToken, std::string const& trainerEntryValue, std::string const& spellIdValue);
 void RunProfessionRecipeCraftCommand(Player* requester, ChatMsg replyType, std::string const& botName, std::string const& requestToken, std::string const& skillIdValue, std::string const& spellIdValue, std::string const& itemIdValue);
+void SendEnchantTradePackets(Player* requester, ChatMsg replyType, std::string const& botName, std::string const& requestToken);
+void RunEnchantTradeCommand(Player* requester, ChatMsg replyType, std::string const& botName, std::string const& requestToken, std::string const& spellIdValue);
 void RunInventoryItemActionCommand(Player* requester, ChatMsg replyType, std::string const& botName, std::string const& requestToken, std::string const& actionValue, std::string const& itemIdValue, std::string const& countValue);
 void RunGroupRollCommand(Player* requester, ChatMsg replyType, std::string const& requestToken, std::string const& modeValue, std::string const& encodedItemLink);
 void RunFormationCommand(Player* requester, ChatMsg replyType, std::string const& scopeValue, std::string const& encodedTarget, std::string const& requestToken, std::string const& encodedFormation);
@@ -1733,6 +1739,17 @@ std::string GetSpellCastFailureReason(SpellCastResult result)
             return "NOT_READY";
         case SPELL_FAILED_OUT_OF_RANGE:
             return "OUT_OF_RANGE";
+        case SPELL_FAILED_NOT_TRADING:
+            return "NO_TRADE";
+        case SPELL_FAILED_ITEM_ALREADY_ENCHANTED:
+            return "ALREADY_ENCHANTED";
+        case SPELL_FAILED_NOT_TRADEABLE:
+            return "NOT_TRADEABLE";
+        case SPELL_FAILED_BAD_TARGETS:
+        case SPELL_FAILED_ITEM_ENCHANT_TRADE_WINDOW:
+            return "BAD_TARGET";
+        case SPELL_FAILED_AFFECTING_COMBAT:
+            return "IN_COMBAT";
         case SPELL_FAILED_TRY_AGAIN:
             return "TRY_AGAIN";
         default:
@@ -1914,6 +1931,129 @@ std::vector<ProfessionRecipeEntryData> BuildProfessionRecipeEntries(Player* bot,
             return left.spellName < right.spellName;
         return left.spellId < right.spellId;
     });
+
+    return entries;
+}
+
+struct EnchantTradeMaterialData
+{
+    uint32 itemId = 0;
+    uint32 required = 0;
+    uint32 available = 0;
+};
+
+struct EnchantTradeEntryData
+{
+    uint32 spellId = 0;
+    std::string spellName;
+    std::string difficulty;
+    uint32 available = 0;
+    uint32 hasTools = 0;
+    std::vector<EnchantTradeMaterialData> materials;
+};
+
+bool IsEnchantTradeSpell(SpellInfo const* spellInfo)
+{
+    if (!spellInfo || spellInfo->IsPassive())
+        return false;
+
+    for (uint32 effectIndex = 0; effectIndex < MAX_SPELL_EFFECTS; ++effectIndex)
+    {
+        if (spellInfo->Effects[effectIndex].Effect != SPELL_EFFECT_ENCHANT_ITEM)
+            continue;
+
+        SpellItemEnchantmentEntry const* const enchantEntry =
+            sSpellItemEnchantmentStore.LookupEntry(spellInfo->Effects[effectIndex].MiscValue);
+        if (enchantEntry && !(enchantEntry->slot & ENCHANTMENT_CAN_SOULBOUND))
+            return true;
+    }
+
+    return false;
+}
+
+void BuildEnchantTradeMaterials(SpellInfo const* spellInfo, std::map<uint32, uint32> const& itemCounts,
+    std::vector<EnchantTradeMaterialData>& materials, uint32& available)
+{
+    materials.clear();
+    available = spellInfo ? 1 : 0;
+    if (!spellInfo)
+        return;
+
+    for (uint32 index = 0; index < MAX_SPELL_REAGENTS; ++index)
+    {
+        if (spellInfo->Reagent[index] <= 0 || spellInfo->ReagentCount[index] <= 0)
+            continue;
+
+        EnchantTradeMaterialData material;
+        material.itemId = static_cast<uint32>(spellInfo->Reagent[index]);
+        material.required = spellInfo->ReagentCount[index];
+        material.available = itemCounts.count(material.itemId) ? itemCounts.at(material.itemId) : 0;
+        if (material.available < material.required)
+            available = 0;
+        materials.push_back(material);
+    }
+}
+
+std::string ValidateEnchantTradeSpellIdentity(Player* bot, uint32 spellId, SpellInfo const*& spellInfo)
+{
+    spellInfo = nullptr;
+    if (!bot || !spellId)
+        return "BAD_REQUEST";
+
+    if (!bot->HasSkill(SKILL_ENCHANTING))
+        return "NOT_ENCHANTER";
+
+    if (!IsKnownActiveBotSpell(bot, spellId))
+        return "UNKNOWN_ENCHANT";
+
+    SkillLineAbilityEntry const* const skillLine = GetSkillLineAbilityForSpell(spellId);
+    if (!skillLine || skillLine->SkillLine != SKILL_ENCHANTING)
+        return "BAD_ENCHANT";
+
+    spellInfo = sSpellMgr->GetSpellInfo(spellId);
+    if (!IsEnchantTradeSpell(spellInfo))
+        return "BAD_ENCHANT";
+
+    return "OK";
+}
+
+std::vector<EnchantTradeEntryData> BuildEnchantTradeEntries(Player* bot)
+{
+    std::vector<EnchantTradeEntryData> entries;
+    if (!bot || !bot->HasSkill(SKILL_ENCHANTING))
+        return entries;
+
+    std::map<uint32, uint32> const itemCounts = BuildBotInventoryItemCounts(bot);
+    for (PlayerSpellMap::const_iterator it = bot->GetSpellMap().begin(); it != bot->GetSpellMap().end(); ++it)
+    {
+        SpellInfo const* spellInfo = nullptr;
+        if (ValidateEnchantTradeSpellIdentity(bot, it->first, spellInfo) != "OK" || !spellInfo || !spellInfo->SpellName[0])
+            continue;
+
+        SkillLineAbilityEntry const* const skillLine = GetSkillLineAbilityForSpell(it->first);
+        if (!skillLine)
+            continue;
+
+        EnchantTradeEntryData entry;
+        entry.spellId = it->first;
+        entry.spellName = spellInfo->SpellName[0];
+        entry.difficulty = GetRecipeDifficulty(bot, skillLine);
+        BuildEnchantTradeMaterials(spellInfo, itemCounts, entry.materials, entry.available);
+        entry.hasTools = BotHasRecipeRequiredTools(bot, spellInfo) ? 1 : 0;
+        if (!entry.hasTools)
+            entry.available = 0;
+        entries.push_back(entry);
+    }
+
+    std::sort(entries.begin(), entries.end(), [](EnchantTradeEntryData const& left, EnchantTradeEntryData const& right)
+    {
+        if (left.spellName != right.spellName)
+            return left.spellName < right.spellName;
+        return left.spellId < right.spellId;
+    });
+
+    if (entries.size() > kMaxEnchantTradeEntries)
+        entries.resize(kMaxEnchantTradeEntries);
 
     return entries;
 }
@@ -4338,6 +4478,47 @@ bool ConsumeGroupRollRateLimit(Player* requester)
     return true;
 }
 
+struct EnchantTradeRateState
+{
+    std::deque<std::chrono::steady_clock::time_point> requests;
+};
+
+std::map<std::string, EnchantTradeRateState> sEnchantTradeRateStates;
+
+bool ConsumeEnchantTradeRateLimit(Player* requester)
+{
+    if (!requester)
+        return false;
+
+    std::chrono::steady_clock::time_point const now = std::chrono::steady_clock::now();
+    std::string const key = requester->GetName();
+    EnchantTradeRateState& state = sEnchantTradeRateStates[key];
+
+    while (!state.requests.empty() && now - state.requests.front() >= kEnchantTradeRateWindow)
+        state.requests.pop_front();
+
+    if (state.requests.size() >= kEnchantTradeRateLimit)
+        return false;
+
+    state.requests.push_back(now);
+
+    if (sEnchantTradeRateStates.size() > 512)
+    {
+        for (auto it = sEnchantTradeRateStates.begin(); it != sEnchantTradeRateStates.end();)
+        {
+            while (!it->second.requests.empty() && now - it->second.requests.front() >= kEnchantTradeRateWindow)
+                it->second.requests.pop_front();
+
+            if (it->second.requests.empty() && it->first != key)
+                it = sEnchantTradeRateStates.erase(it);
+            else
+                ++it;
+        }
+    }
+
+    return true;
+}
+
 void RunGroupRollCommand(Player* requester, ChatMsg replyType, std::string const& requestToken, std::string const& modeValue, std::string const& encodedItemLink)
 {
     std::string const token = Trim(requestToken);
@@ -4605,6 +4786,188 @@ void RunInventoryItemActionCommand(Player* requester, ChatMsg replyType, std::st
         << kFieldSeparator << moved;
 
     SendAddonPacket(requester, replyType, "INVENTORY_ITEM_ACTION", payload.str());
+}
+
+void SendEnchantTradePackets(Player* requester, ChatMsg replyType, std::string const& botName, std::string const& requestToken)
+{
+    std::string const trimmedBotName = Trim(botName);
+    std::string const token = Trim(requestToken);
+    Player* const bot = FindBotByName(requester, trimmedBotName);
+    std::string const effectiveBotName = bot ? bot->GetName() : "";
+    std::string reason = "OK";
+
+    if (!ConsumeEnchantTradeRateLimit(requester))
+        reason = "RATE_LIMIT";
+    else if (!bot)
+        reason = "NO_BOT";
+    else
+    {
+        PlayerbotAI* const botAI = GetBotAI(bot);
+        if (!botAI || !botAI->GetSecurity() ||
+            !botAI->GetSecurity()->CheckLevelFor(PLAYERBOT_SECURITY_ALLOW_ALL, true, requester))
+        {
+            reason = "FORBIDDEN";
+        }
+        else if (!bot->HasSkill(SKILL_ENCHANTING))
+            reason = "NOT_ENCHANTER";
+    }
+
+    uint32 const skillValue = bot && bot->HasSkill(SKILL_ENCHANTING) ? bot->GetSkillValue(SKILL_ENCHANTING) : 0;
+    uint32 const maxSkill = bot && bot->HasSkill(SKILL_ENCHANTING) ? bot->GetMaxSkillValue(SKILL_ENCHANTING) : 0;
+    bool const ok = reason == "OK";
+
+    std::ostringstream beginPayload;
+    beginPayload << UrlEncodeField(effectiveBotName)
+        << kFieldSeparator << token
+        << kFieldSeparator << (ok ? "OK" : "ERR")
+        << kFieldSeparator << UrlEncodeField(reason)
+        << kFieldSeparator << skillValue
+        << kFieldSeparator << maxSkill;
+    SendAddonPacket(requester, replyType, "ENCHANT_TRADE_BEGIN", beginPayload.str());
+
+    uint32 count = 0;
+    if (ok)
+    {
+        for (EnchantTradeEntryData const& entry : BuildEnchantTradeEntries(bot))
+        {
+            std::ostringstream payload;
+            payload << UrlEncodeField(effectiveBotName)
+                << kFieldSeparator << token
+                << kFieldSeparator << entry.spellId
+                << kFieldSeparator << UrlEncodeField(entry.difficulty)
+                << kFieldSeparator << entry.available
+                << kFieldSeparator << entry.hasTools;
+            if (!IsAddonPacketWithinBudget("ENCHANT_TRADE_ITEM", payload.str()))
+                continue;
+
+            SendAddonPacket(requester, replyType, "ENCHANT_TRADE_ITEM", payload.str());
+            for (EnchantTradeMaterialData const& material : entry.materials)
+            {
+                std::ostringstream materialPayload;
+                materialPayload << UrlEncodeField(effectiveBotName)
+                    << kFieldSeparator << token
+                    << kFieldSeparator << entry.spellId
+                    << kFieldSeparator << material.itemId
+                    << kFieldSeparator << material.required
+                    << kFieldSeparator << material.available;
+                if (IsAddonPacketWithinBudget("ENCHANT_TRADE_MATERIAL", materialPayload.str()))
+                    SendAddonPacket(requester, replyType, "ENCHANT_TRADE_MATERIAL", materialPayload.str());
+            }
+            ++count;
+        }
+    }
+
+    std::ostringstream endPayload;
+    endPayload << UrlEncodeField(effectiveBotName)
+        << kFieldSeparator << token
+        << kFieldSeparator << (ok ? "OK" : "ERR")
+        << kFieldSeparator << UrlEncodeField(reason)
+        << kFieldSeparator << count;
+    SendAddonPacket(requester, replyType, "ENCHANT_TRADE_END", endPayload.str());
+}
+
+std::string ValidateEnchantTradeContext(Player* requester, Player* bot, uint32 spellId, SpellInfo const*& spellInfo)
+{
+    if (!requester || !bot)
+        return "BAD_REQUEST";
+
+    PlayerbotAI* const botAI = GetBotAI(bot);
+    if (!botAI || !botAI->GetSecurity() ||
+        !botAI->GetSecurity()->CheckLevelFor(PLAYERBOT_SECURITY_ALLOW_ALL, true, requester))
+    {
+        return "FORBIDDEN";
+    }
+
+    if (!bot->GetSession())
+        return "NO_SESSION";
+
+    std::string const identityReason = ValidateEnchantTradeSpellIdentity(bot, spellId, spellInfo);
+    if (identityReason != "OK")
+        return identityReason;
+
+    if (!BotHasRecipeRequiredTools(bot, spellInfo))
+        return "MISSING_TOOLS";
+
+    uint32 materialsAvailable = 0;
+    std::vector<EnchantTradeMaterialData> materials;
+    BuildEnchantTradeMaterials(spellInfo, BuildBotInventoryItemCounts(bot), materials, materialsAvailable);
+    if (!materialsAvailable)
+        return "NO_MATERIALS";
+
+    if (bot->IsInCombat())
+        return "IN_COMBAT";
+    if (bot->HasUnitState(UNIT_STATE_LOST_CONTROL))
+        return "LOST_CONTROL";
+    if (bot->IsFlying() || bot->HasUnitState(UNIT_STATE_IN_FLIGHT))
+        return "IN_FLIGHT";
+    if (bot->GetCurrentSpell(CURRENT_CHANNELED_SPELL) != nullptr)
+        return "CHANNELING";
+    if (bot->HasSpellCooldown(spellId))
+        return "NOT_READY";
+    if (!bot->IsStandState())
+    {
+        bot->SetStandState(UNIT_STAND_STATE_STAND);
+        return "NOT_STANDING";
+    }
+
+    uint32 const castTime = !spellInfo->IsChanneled() ? spellInfo->CalcCastTime(bot) : spellInfo->GetDuration();
+    if ((castTime || spellInfo->IsAutoRepeatRangedSpell()) && bot->isMoving())
+        return "MOVING";
+
+    TradeData* const botTrade = bot->GetTradeData();
+    TradeData* const requesterTrade = requester ? requester->GetTradeData() : nullptr;
+    if (!botTrade || !requesterTrade)
+        return "NO_TRADE";
+    if (botTrade->GetTrader() != requester || requesterTrade->GetTrader() != bot)
+        return "WRONG_TRADER";
+    if (!requesterTrade->GetItem(TRADE_SLOT_NONTRADED))
+        return "NO_TRADE_ITEM";
+    if (botTrade->GetSpell())
+        return "ALREADY_ENCHANTED";
+
+    return "OK";
+}
+
+void RunEnchantTradeCommand(Player* requester, ChatMsg replyType, std::string const& botName, std::string const& requestToken, std::string const& spellIdValue)
+{
+    std::string const trimmedBotName = Trim(botName);
+    std::string const token = Trim(requestToken);
+    uint32 spellId = 0;
+    TryParseUint32Field(Trim(spellIdValue), 1, std::numeric_limits<uint32>::max(), spellId);
+
+    Player* const bot = FindBotByName(requester, trimmedBotName);
+    std::string const effectiveBotName = bot ? bot->GetName() : "";
+    std::string reason = "OK";
+    bool accepted = false;
+
+    if (!ConsumeEnchantTradeRateLimit(requester))
+        reason = "RATE_LIMIT";
+    else if (!bot)
+        reason = "NO_BOT";
+    else
+    {
+        SpellInfo const* spellInfo = nullptr;
+        reason = ValidateEnchantTradeContext(requester, bot, spellId, spellInfo);
+        if (reason == "OK")
+        {
+            SpellCastTargets targets;
+            targets.SetTradeItemTarget(bot);
+
+            Spell* const spell = new Spell(bot, spellInfo, TRIGGERED_NONE);
+            SpellCastResult const result = spell->prepare(&targets);
+            reason = GetSpellCastFailureReason(result);
+            accepted = result == SPELL_CAST_OK;
+        }
+    }
+
+    std::ostringstream payload;
+    payload << UrlEncodeField(effectiveBotName)
+        << kFieldSeparator << token
+        << kFieldSeparator << spellId
+        << kFieldSeparator << (accepted ? "OK" : "ERR")
+        << kFieldSeparator << UrlEncodeField(reason)
+        << kFieldSeparator << (accepted ? 1 : 0);
+    SendAddonPacket(requester, replyType, "ENCHANT_TRADE_RESULT", payload.str());
 }
 
 void RunProfessionRecipeCraftCommand(Player* requester, ChatMsg replyType, std::string const& botName, std::string const& requestToken, std::string const& skillIdValue, std::string const& spellIdValue, std::string const& itemIdValue)
@@ -6387,7 +6750,7 @@ bool HandleBridgeOpcode(Player* player, ChatMsg replyType, std::string const& op
             player,
             replyType,
             "CAPS",
-            std::string(kStateFramingCapability) + "," + kStrategyMutationCapability + "," + kOutfitCapability + "," + kInventoryCapability + "," + kInventoryBulkSellCapability + "," + kInventoryOpenCapability + "," + kGroupRollCapability);
+            std::string(kStateFramingCapability) + "," + kStrategyMutationCapability + "," + kOutfitCapability + "," + kInventoryCapability + "," + kInventoryBulkSellCapability + "," + kInventoryOpenCapability + "," + kGroupRollCapability + "," + kEnchantTradeCapability);
         return true;
     }
 
@@ -6680,6 +7043,22 @@ bool HandleBridgeOpcode(Player* player, ChatMsg replyType, std::string const& op
             return true;
         }
 
+        if (requestType == "ENCHANT_TRADE")
+        {
+            std::string const token = GetSafeErrorToken(fields, 2);
+            if (fields.size() != 3)
+                return SendProtocolError(player, replyType, normalized, requestType, token, "BAD_FIELD_COUNT");
+
+            if (!IsValidCanonicalRawField(fields[1], kMaxBotNameLength, false))
+                return SendProtocolError(player, replyType, normalized, requestType, token, "BAD_BOT_NAME");
+
+            if (!IsValidRequestToken(fields[2]))
+                return SendProtocolError(player, replyType, normalized, requestType, "", "BAD_TOKEN");
+
+            SendEnchantTradePackets(player, replyType, fields[1], fields[2]);
+            return true;
+        }
+
         if (requestType == "PROFESSION_RECIPES")
         {
             std::string const token = GetSafeErrorToken(fields, 3);
@@ -6746,6 +7125,26 @@ bool HandleBridgeOpcode(Player* player, ChatMsg replyType, std::string const& op
             return SendProtocolError(player, replyType, normalized, requestType, token, "BAD_NUMBER");
 
         RunTrainerLearnCommand(player, replyType, fields[1], fields[2], fields[3], fields[4]);
+        return true;
+    }
+
+    if (requestType == "ENCHANT_TRADE")
+    {
+        std::string const token = GetSafeErrorToken(fields, 2);
+        if (fields.size() != 4)
+            return SendProtocolError(player, replyType, normalized, requestType, token, "BAD_FIELD_COUNT");
+
+        if (!IsValidCanonicalRawField(fields[1], kMaxBotNameLength, false))
+            return SendProtocolError(player, replyType, normalized, requestType, token, "BAD_BOT_NAME");
+
+        if (!IsValidRequestToken(fields[2]))
+            return SendProtocolError(player, replyType, normalized, requestType, "", "BAD_TOKEN");
+
+        uint32 spellId = 0;
+        if (!TryParseUint32Field(fields[3], 1, std::numeric_limits<uint32>::max(), spellId))
+            return SendProtocolError(player, replyType, normalized, requestType, token, "BAD_NUMBER");
+
+        RunEnchantTradeCommand(player, replyType, fields[1], fields[2], fields[3]);
         return true;
     }
 


### PR DESCRIPTION
## Summary

Adds the bridge side of the negotiated `ENCHANT_TRADE_V1` Enchanting Trade Service.

The feature exposes only Enchanting spells actually known by the selected bot and executes a validated numeric spell ID against the player's native non-traded WoW Trade item.

## Implementation

Adds structured `GET~ENCHANT_TRADE` and `RUN~ENCHANT_TRADE` handling with framed Enchant Trade responses.

The bridge validates the requester, bot control/security, session/state, Enchanting skill, known active spell, Enchanting spell effect, tools, reagents, Trade partner and `TRADE_SLOT_NONTRADED` target.

Execution uses the native Core trade-item spell path through `SpellCastTargets::SetTradeItemTarget()`.

The capability is rate-limited to 4 requests per 2-second window and limits the returned enchant list to 256 entries.

No generic Playerbots command executor, arbitrary cast endpoint or automatic chat path is introduced.

## Validation

- CMake rerun not required
- worldserver build: 20 succeeded, 0 failed
- real in-game enchant successfully applied through the normal WoW Trade flow
- no automatic chat spam observed
- `git diff --check`: OK
- Playerbots remained strictly read-only
- final pre-PR audit: OK, 0 failures, 0 warnings

## Documentation

README updated with the protocol, validation model, native Trade targeting and current roadmap state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Ajout de l’opération **Enchanting Trade** pour découvrir les enchantements disponibles et préparer un enchantement via le commerce.
  * Prise en charge des validations des compétences, outils, matériaux, objets échangeables, ressources et état du commerce.
  * Ajout de contrôles de sécurité, de limitations de débit et de messages d’erreur détaillés.
  * Annonce de la nouvelle capacité lors de la découverte des fonctionnalités.

* **Documentation**
  * Mise à jour du protocole pour **Group Roll**, les domaines pris en charge et les validations associées.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->