### PR TITLE
Fix use-after-free crash in AppendBridgeVisibleBot

### DIFF
--- a/src/MultiBotBridge.cpp
+++ b/src/MultiBotBridge.cpp
@@ -9082,7 +9082,7 @@ bool CanExposeRandomHolderBot(Player* requester, Player* bot)
 
 void AppendBridgeVisibleBot(Player* bot, std::vector<Player*>& bots, std::set<ObjectGuid>& seen)
 {
-    if (!bot)
+    if (!bot || !bot->IsInWorld())
         return;
 
     if (!seen.insert(bot->GetGUID()).second)


### PR DESCRIPTION
## Summary
- `AppendBridgeVisibleBot` only null-checked the `Player*` pointer, not whether the bot was still attached to the world.
- A bot mid-teleport/logout between the roster snapshot and its use (e.g. entering an LFG queue) could leave a dangling pointer, crashing `SendDetailPackets`, `BuildRosterPayload`, `SendStatePackets`, and the other consumers of `GetBridgeVisibleBots()` with a SIGSEGV.
- Adds `!bot->IsInWorld()` to the existing check at the single choke point all bridge lookup functions go through, closing the race without touching each call site individually.

## Root cause
Traced this from a live worldserver crash: `journalctl` showed the SIGSEGV occurring mid-write of a `MultiBotBridge TX/RX` log line, with heavy `GET~DETAILS` traffic overlapping bots entering LFG dungeon queues right before the crash.

## Test plan
- [x] Patched and running in production since 2026-08-04 with no recurrence of the crash.
- [ ] No unit tests in this module to extend; the fix is a single defensive check at the shared entry point used by all bridge consumers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Correctifs**
  * Les bots absents du monde ne sont plus affichés dans la liste des bots visibles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->